### PR TITLE
Add deck simulation tests and starter script

### DIFF
--- a/start_simulation/run_simulation.py
+++ b/start_simulation/run_simulation.py
@@ -1,0 +1,39 @@
+from simulations.scripts.deck_calculations_script import SphereDeckCalculator
+
+
+def main():
+    calculator = SphereDeckCalculator(
+        "Deck Dimensions of a Sphere",
+        sphere_diameter=127.0,
+        hull_thickness=0.5,
+        windows_per_deck_ratio=0.20,
+        num_decks=16,
+        deck_000_outer_radius=10.5,
+        deck_height_brutto=3.5,
+        deck_ceiling_thickness=0.5,
+    )
+
+    calculator.calculate_dynamics_of_a_sphere(angular_velocity=0.5)
+    print(calculator.to_string())
+    calculator.to_csv("deck_dimensions.csv")
+    calculator.to_html("deck_dimensions.html")
+    calculator.to_3D_animation_show_all_decks("deck_animation.html")
+    calculator.to_3D_animation_rotate_all_decks("deck_animation_rotate.html")
+    calculator.to_3D_animation_rotate_hull_with_windows(
+        "hull_with_windows_animation.html",
+        frames=25,
+        frames_per_second=5,
+        rotation_axis="Z",
+    )
+    calculator.to_3D_animation_rotate_hull("hull_animation.html")
+    calculator.to_3D_animation_rotate_hull_with_gravity_zones(
+        "hull_with_gravity_zones_animation.html",
+        frames=25,
+        frames_per_second=25,
+        rotation_axis="Z",
+        show_gravity_zones=False,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/unit_tests/test_function_calls.py
+++ b/unit_tests/test_function_calls.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from simulations.scripts.deck_calculations_script import SphereDeckCalculator
+
+
+def create_calculator():
+    return SphereDeckCalculator(
+        title="test",
+        sphere_diameter=50.0,
+        hull_thickness=0.5,
+        windows_per_deck_ratio=0.2,
+        num_decks=16,
+        deck_000_outer_radius=5.0,
+        deck_height_brutto=3.0,
+        deck_ceiling_thickness=0.5,
+    )
+
+
+def test_to_csv_and_html(tmp_path):
+    calc = create_calculator()
+    csv_path = tmp_path / "deck_dimensions.csv"
+    html_path = tmp_path / "deck_dimensions.html"
+    calc.to_csv(str(csv_path))
+    calc.to_html(str(html_path))
+    assert csv_path.exists()
+    assert html_path.exists()
+
+
+def test_animations(tmp_path):
+    calc = create_calculator()
+    show_all = tmp_path / "deck_animation.html"
+    rotate_all = tmp_path / "deck_animation_rotate.html"
+    rotate_windows = tmp_path / "hull_with_windows_animation.html"
+    rotate_hull = tmp_path / "hull_animation.html"
+    rotate_gravity = tmp_path / "hull_with_gravity_zones_animation.html"
+
+    calc.to_3D_animation_show_all_decks(str(show_all))
+    calc.to_3D_animation_rotate_all_decks(str(rotate_all), frames=2, frames_per_second=5)
+    calc.to_3D_animation_rotate_hull_with_windows(
+        str(rotate_windows), frames=2, frames_per_second=5, rotation_axis="Z"
+    )
+    calc.to_3D_animation_rotate_hull(str(rotate_hull), frames=2, frames_per_second=5)
+    calc.to_3D_animation_rotate_hull_with_gravity_zones(
+        str(rotate_gravity),
+        frames=2,
+        frames_per_second=5,
+        rotation_axis="Z",
+        show_gravity_zones=False,
+    )
+
+    assert show_all.exists()
+    assert rotate_all.exists()
+    assert rotate_windows.exists()
+    assert rotate_hull.exists()
+    assert rotate_gravity.exists()


### PR DESCRIPTION
## Summary
- add a starter script under `start_simulation` to run the sphere deck calculations
- introduce unit tests in `unit_tests` exercising output functions

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d939357c832a8d133132055772c1