### PR TITLE
Fix VSCode launch path and simulation imports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "Run Simulation",
             "type": "python",
             "request": "launch",
-            "program": "${workspaceFolder}/start_simulation/run_simulation.py",
+            "program": "${workspaceFolder}/simulations/start_simulation/run_simulation.py",
             "console": "integratedTerminal"
         }
     ]

--- a/simulations/start_simulation/run_simulation.py
+++ b/simulations/start_simulation/run_simulation.py
@@ -1,3 +1,8 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
 from simulations.scripts.deck_calculations_script import SphereDeckCalculator
 
 


### PR DESCRIPTION
## Summary
- fix VSCode launch configuration to point at simulation starter
- ensure run_simulation.py can import project modules by updating `sys.path`

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`
- `PYTHONPATH=. pytest simulations/tests/test_geometry.py -q`
- `PYTHONPATH=. pytest simulations/unit_tests/test_function_calls.py::test_to_csv_and_html -q`
- `PYTHONPATH=. pytest simulations/unit_tests/test_function_calls.py::test_animations -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6887e10e4764832a8602cd82e784b8b2