### PR TITLE
Add Blender recommendations

### DIFF
--- a/recommendations/README.md
+++ b/recommendations/README.md
@@ -1,0 +1,2 @@
+# Recommendations
+This directory contains analysis documents and strategic recommendations for the Sphere Space Station Earth ONE and Beyond project.

--- a/recommendations/blender_simulation_recommendations.md
+++ b/recommendations/blender_simulation_recommendations.md
@@ -1,0 +1,27 @@
+# Blender Simulation Recommendations
+
+This document summarizes an analysis of how Blender or similar 3D rendering engines can enhance simulations and visualizations for the Sphere Space Station Earth ONE and Beyond project.
+
+## Analysis
+- The repository currently includes a Python script (`simulations/scripts/deck_calculations_script.py`) that generates deck geometry and simple animations with Matplotlib.
+- The provided PDF "Bewertung der Dokumentation" advises creating an integrated roadmap and building strategic partnerships.
+- No Blender files or advanced rendering assets are present in the repository.
+
+## Recommendations
+1. **Integrate Blender for High-Fidelity Visualization**
+   - Export geometry data from existing scripts and import it into Blender via its Python API.
+   - Use Blender to apply detailed materials, lighting, and advanced animations.
+
+2. **Extend Simulation Capabilities**
+   - Utilize Blender's physics and particle systems to model life-support flows, assembly sequences, and ergonomic studies.
+
+3. **Leverage Blender for Stakeholder Communication**
+   - High-quality renders and interactive scenes can support funding efforts and public outreach in line with PDF suggestions.
+
+4. **Suggested Pipeline**
+   - Generate geometry → export to GLTF/FBX → import into Blender → apply materials and animations.
+   - Automate this pipeline so updated engineering data translates easily into new renders.
+
+5. **Licensing Considerations**
+   - Simulation scripts are MIT-licensed; maintain attribution when integrating with Blender.
+   - Respect proprietary and CC BY-4.0 licenses for documentation and derivative works.


### PR DESCRIPTION
## Summary
- add a `recommendations` folder for analysis documents
- document folder purpose in README
- include analysis of Blender for simulation and visualization

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`


------
https://chatgpt.com/codex/tasks/task_e_68888fb01cb4832aa40c4f5651836c2a