### PR TITLE
Add missing READMEs

### DIFF
--- a/project/README.md
+++ b/project/README.md
@@ -1,0 +1,3 @@
+# Project Management
+
+This directory collects high-level management material for the Blender simulation initiative within the Sphere Space Station project. The main document is **Blender Simulation Projektplan.docx**, outlining the simulation concept and future improvements. Additional controlling files are stored in the `controlling` subfolder.

--- a/project/controlling/README.md
+++ b/project/controlling/README.md
@@ -1,0 +1,3 @@
+# Controlling
+
+The `controlling` folder contains planning documents that track milestones and phases of the Sphere Station project. See `Roadmap_de.md` for the overall roadmap in German.

--- a/simulations/blender_simulation/README.md
+++ b/simulations/blender_simulation/README.md
@@ -1,0 +1,22 @@
+# Blender Simulation
+
+This folder contains the proof-of-concept Blender files for visualizing the Sphere Station decks.
+
+* **blender_deck_simulation.py** – Blender Python script that builds ring segments from `deck_3d_construction_data.csv`.
+* **deck_3d_construction_data.csv** – Geometry values derived from the deck calculations.
+* **Blender Simulation Projektplan.docx** (in `../project`) – high-level plan describing data structure and further work.
+* **Blender Simulation Sprintplan.docx** – sprint tasks for setting up this folder.
+
+To run the script in Blender:
+
+1. Open Blender (version ≥ 2.9) and switch to the *Scripting* workspace.
+2. Load `blender_deck_simulation.py`, adjust the CSV path if necessary and press `Alt+P`.
+3. The generated objects appear under `SphereDeckCollection`.
+
+The script can also be executed from the command line:
+
+```
+blender --python simulations/blender_simulation/blender_deck_simulation.py --background
+```
+
+This will create a `.blend` file in background mode for further processing.


### PR DESCRIPTION
## Summary
- add project overview README and controlling subfolder README
- document Blender simulation folder with usage instructions
- run unit tests

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ad5fad5c832a9b176ba23677f0a2