### PR TITLE
Improve Blender variable naming and docs

### DIFF
--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -1,0 +1,11 @@
+# Konstruktionshandbuch
+
+Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Space Station und dient als fortlaufende Dokumentation.
+
+## Aktueller Stand
+
+- **Deckdaten** basieren auf den Berechnungen aus `deck_calculations_script.py` und werden für Blender in `deck_3d_construction_data.csv` aufbereitet.
+- **Variablennamen** wurden auf ein konsistentes, PEP8‑konformes Schema umgestellt (z.B. `deck_id`, `inner_radius_m`).
+- **Blender-Skripte** erzeugen realistisch proportionierte Decks und ein zentrales Wurmloch. Materialien und Fenster werden anhand der CSV‑Daten gesetzt.
+
+Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/blender_simulation/README.md
+++ b/simulations/blender_simulation/README.md
@@ -14,20 +14,19 @@ Dieser Ordner enthält die Proof-of-Concept-Dateien für Blender, mit denen die 
 
 | Spalte | Bedeutung |
 |-------|-----------|
-| `Deck` | Name bzw. Nummer des Decks |
-| `usage` | vorgesehene Nutzung |
-| `Inner Radius (m)` | Abstand vom Mittelpunkt bis zur inneren Deckwand |
-| `Outer Radius (m)` | Abstand bis zur äußeren Deckwand |
-| `Outer Radius netto (m)` | nutzbarer Außenradius nach Abzug des Hüllmaterials |
-| `radial_thickness_m` | Dicke des Ringsegments zwischen Innen- und Außenradius |
-| `Deck Height (m)` | Gesamthöhe des Decks (brutto) |
-| `Deck Height netto (m)` | nutzbare Innenhöhe |
-| `windows_count` | Anzahl der Fenster |
+| `deck_id` | Name bzw. Nummer des Decks |
+| `deck_usage` | vorgesehene Nutzung |
+| `inner_radius_m` | Abstand vom Mittelpunkt bis zur inneren Deckwand |
+| `outer_radius_m` | Abstand bis zur äußeren Deckwand |
+| `outer_radius_netto_m` | nutzbarer Außenradius nach Abzug des Hüllmaterials |
+| `deck_height_m` | Gesamthöhe des Decks (brutto) |
+| `deck_inner_height_m` | nutzbare Innenhöhe |
+| `num_windows` | Anzahl der Fenster |
 | `window_material` | verwendetes Fenstermaterial |
-| `window_total_thickness_cm` | Gesamtdicke der Fenster in Zentimetern |
+| `window_thickness_cm` | Gesamtdicke der Fenster in Zentimetern |
 | `structure_material` | Baumaterial des Decks |
-| `Rotation Velocity @ radius netto (m/s)` | Umfangsgeschwindigkeit am nutzbaren Außenradius |
-| `Centrifugal Acceleration @ radius netto (m/s²)` | Zentrifugalbeschleunigung am nutzbaren Außenradius |
+| `rotation_velocity_mps` | Umfangsgeschwindigkeit am nutzbaren Außenradius |
+| `centrifugal_acceleration_mps2` | Zentrifugalbeschleunigung am nutzbaren Außenradius |
 
 ## Generierung der CSV-Datei
 

--- a/simulations/blender_simulation/blender_deck_simulation.py
+++ b/simulations/blender_simulation/blender_deck_simulation.py
@@ -33,10 +33,10 @@ Input CSV
 
 The CSV used by this script should contain, at minimum, the following columns:
 
-* ``Deck`` – unique name (e.g. ``Deck 001``)
-* ``Inner Radius (m)`` – radial distance from the centre to the inner wall of the deck
-* ``Outer Radius (m)`` – radial distance to the outer wall of the deck
-* ``Deck Height (m)`` – overall vertical deck height (brutto)
+* ``deck_id`` – unique name (e.g. ``Deck_001``)
+* ``inner_radius_m`` – radial distance from the centre to the inner wall of the deck
+* ``outer_radius_m`` – radial distance to the outer wall of the deck
+* ``deck_height_m`` – overall vertical deck height (brutto)
 
 Additional columns (usage, materials, etc.) are ignored by the script but
 present in the example input for completeness.
@@ -190,10 +190,10 @@ def load_deck_data(csv_path: str) -> list:
         reader = csv.DictReader(f)
         for row in reader:
             deck_info = {
-                "deck_name": row["Deck"],
-                "inner_radius": float(row["Inner Radius (m)"]),
-                "outer_radius": float(row["Outer Radius (m)"]),
-                "height": float(row["Deck Height (m)"]),
+                "deck_name": row["deck_id"],
+                "inner_radius": float(row["inner_radius_m"]),
+                "outer_radius": float(row["outer_radius_m"]),
+                "height": float(row["deck_height_m"]),
             }
             decks.append(deck_info)
     return decks

--- a/simulations/blender_simulation/deck_3d_construction_data.csv
+++ b/simulations/blender_simulation/deck_3d_construction_data.csv
@@ -1,17 +1,17 @@
-Deck,usage,Inner Radius (m),Outer Radius (m),Outer Radius netto (m),radial_thickness_m,Deck Height (m),Deck Height netto (m),windows_count,window_material,window_total_thickness_cm,structure_material,Rotation Velocity @ radius netto (m/s),Centrifugal Acceleration @ radius netto (m/s²)
-Deck 000,Docking & Command Center,0.0,10.5,10.0,10.5,10.5,10.0,6,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,5.0,2.5
-Deck 001,Residential/Operational,10.5,14.0,13.5,3.5,3.5,3.0,8,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,6.75,3.375
-Deck 002,Residential/Operational,14.0,17.5,17.0,3.5,3.5,3.0,10,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,8.5,4.25
-Deck 003,Residential/Operational,17.5,21.0,20.5,3.5,3.5,3.0,12,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,10.25,5.125
-Deck 004,Residential/Operational,21.0,24.5,24.0,3.5,3.5,3.0,15,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,12.0,6.0
-Deck 005,Residential/Operational,24.5,28.0,27.5,3.5,3.5,3.0,17,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,13.75,6.875
-Deck 006,Residential/Operational,28.0,31.5,31.0,3.5,3.5,3.0,19,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,15.5,7.75
-Deck 007,Residential/Operational,31.5,35.0,34.5,3.5,3.5,3.0,21,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,17.25,8.625
-Deck 008,Industrial/Recreational,35.0,38.5,38.0,3.5,3.5,3.0,23,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,19.0,9.5
-Deck 009,Industrial/Recreational,38.5,42.0,41.5,3.5,3.5,3.0,26,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,20.75,10.375
-Deck 010,Industrial/Recreational,42.0,45.5,45.0,3.5,3.5,3.0,28,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,22.5,11.25
-Deck 011,Industrial/Recreational,45.5,49.0,48.5,3.5,3.5,3.0,30,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,24.25,12.125
-Deck 012,Industrial/Recreational,49.0,52.5,52.0,3.5,3.5,3.0,32,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,26.0,13.0
-Deck 013,Storage/Propulsion,52.5,56.0,55.5,3.5,3.5,3.0,34,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,27.75,13.875
-Deck 014,Storage/Propulsion,56.0,59.5,59.0,3.5,3.5,3.0,37,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,29.5,14.75
-Deck 015,Storage/Propulsion,59.5,63.0,62.5,3.5,3.5,3.0,39,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,31.25,15.625
+deck_id,deck_usage,inner_radius_m,outer_radius_m,outer_radius_netto_m,deck_height_m,deck_inner_height_m,num_windows,window_material,window_thickness_cm,structure_material,rotation_velocity_mps,centrifugal_acceleration_mps2
+Deck 000,Docking & Command Center,0.0,10.5,10.0,10.5,10.0,6,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,5.0,2.5
+Deck 001,Residential/Operational,10.5,14.0,13.5,3.5,3.0,8,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,6.75,3.375
+Deck 002,Residential/Operational,14.0,17.5,17.0,3.5,3.0,10,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,8.5,4.25
+Deck 003,Residential/Operational,17.5,21.0,20.5,3.5,3.0,12,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,10.25,5.125
+Deck 004,Residential/Operational,21.0,24.5,24.0,3.5,3.0,15,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,12.0,6.0
+Deck 005,Residential/Operational,24.5,28.0,27.5,3.5,3.0,17,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,13.75,6.875
+Deck 006,Residential/Operational,28.0,31.5,31.0,3.5,3.0,19,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,15.5,7.75
+Deck 007,Residential/Operational,31.5,35.0,34.5,3.5,3.0,21,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,17.25,8.625
+Deck 008,Industrial/Recreational,35.0,38.5,38.0,3.5,3.0,23,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,19.0,9.5
+Deck 009,Industrial/Recreational,38.5,42.0,41.5,3.5,3.0,26,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,20.75,10.375
+Deck 010,Industrial/Recreational,42.0,45.5,45.0,3.5,3.0,28,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,22.5,11.25
+Deck 011,Industrial/Recreational,45.5,49.0,48.5,3.5,3.0,30,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,24.25,12.125
+Deck 012,Industrial/Recreational,49.0,52.5,52.0,3.5,3.0,32,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,26.0,13.0
+Deck 013,Storage/Propulsion,52.5,56.0,55.5,3.5,3.0,34,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,27.75,13.875
+Deck 014,Storage/Propulsion,56.0,59.5,59.0,3.5,3.0,37,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,29.5,14.75
+Deck 015,Storage/Propulsion,59.5,63.0,62.5,3.5,3.0,39,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,31.25,15.625

--- a/simulations/blender_simulation/generate_3d_construction_csv.py
+++ b/simulations/blender_simulation/generate_3d_construction_csv.py
@@ -36,30 +36,29 @@ def main() -> None:
     if df.columns[0].startswith("Unnamed"):
         df = df.drop(df.columns[0], axis=1)
 
-    df = df[df["Deck"].notna()].reset_index(drop=True)  # drop footer rows
+    df = df[df["deck_id"].notna()].reset_index(drop=True)  # drop footer rows
 
-    df["usage"] = [USAGE_MAP.get(i, "") for i in range(len(df))]
-    df["radial_thickness_m"] = df["Outer Radius (m)"] - df["Inner Radius (m)"]
-    df["windows_count"] = [math.floor(r / 1.6) for r in df["Outer Radius netto (m)"]]
+    df["deck_usage"] = [USAGE_MAP.get(i, "") for i in range(len(df))]
+    df["deck_height_m"] = df["outer_radius_m"] - df["inner_radius_m"]
+    df["num_windows"] = [math.floor(r / 1.6) for r in df["outer_radius_netto_m"]]
     df["window_material"] = WINDOW_MATERIAL
-    df["window_total_thickness_cm"] = WINDOW_THICKNESS_CM
+    df["window_thickness_cm"] = WINDOW_THICKNESS_CM
     df["structure_material"] = STRUCTURE_MATERIAL
 
     cols = [
-        "Deck",
-        "usage",
-        "Inner Radius (m)",
-        "Outer Radius (m)",
-        "Outer Radius netto (m)",
-        "radial_thickness_m",
-        "Deck Height (m)",
-        "Deck Height netto (m)",
-        "windows_count",
+        "deck_id",
+        "deck_usage",
+        "inner_radius_m",
+        "outer_radius_m",
+        "outer_radius_netto_m",
+        "deck_height_m",
+        "deck_inner_height_m",
+        "num_windows",
         "window_material",
-        "window_total_thickness_cm",
+        "window_thickness_cm",
         "structure_material",
-        "Rotation Velocity @ radius netto (m/s)",
-        "Centrifugal Acceleration @ radius netto (m/s²)",
+        "rotation_velocity_mps",
+        "centrifugal_acceleration_mps2",
     ]
 
     df[cols].to_csv(OUTPUT_CSV, index=False)

--- a/simulations/scripts/deck_calculations_script.py
+++ b/simulations/scripts/deck_calculations_script.py
@@ -28,23 +28,23 @@ def _resolve_output_path(file_path: str | None) -> str | None:
 
 
 class SphereDeckCalculator:
-    DECK_LABEL = "Deck"
+    DECK_ID_LABEL = "deck_id"
     DECK_NAME = "Deck_"  # Deck name prefix
-    INNER_RADIUS_LABEL = "Inner Radius (m)"
-    OUTER_RADIUS_LABEL = "Outer Radius (m)"
-    OUTER_RADIUS_NETTO_LABEL = "Outer Radius netto (m)"
-    CEILING_THICKNESS_LABEL = "Ceiling Thickness (m)"
-    DECK_HEIGHT_LABEL = "Deck Height (m)"
-    DECK_HEIGHT_NETTO_LABEL = "Deck Height netto (m)"
-    LENGTH_INNER_RADIUS_LABEL = "Length at Inner Radius (m)"
-    LENGTH_OUTER_RADIUS_LABEL = "Length at Outer Radius (m)"
-    LENGTH_OUTER_RADIUS_NETTO_LABEL = "Length at Outer Radius netto (m)"
-    BASE_AREA_INNER_RADIUS_LABEL = "Base Area at Inner Radius (m²)"
-    BASE_AREA_OUTER_RADIUS_LABEL = "Base Area at Outer Radius (m²)"
-    EFFECTIVE_VOLUME_LABEL = "Effective Volume (m³)"
-    NET_ROOM_VOLUME_LABEL = "Net Room Volume (m³)"
-    ROTATION_VELOCITY_LABEL = "Rotation Velocity @ radius netto (m/s)"
-    CENTRIFUGAL_ACCELERATION_LABEL = "Centrifugal Acceleration @ radius netto (m/s²)"
+    INNER_RADIUS_LABEL = "inner_radius_m"
+    OUTER_RADIUS_LABEL = "outer_radius_m"
+    OUTER_RADIUS_NETTO_LABEL = "outer_radius_netto_m"
+    CEILING_THICKNESS_LABEL = "ceiling_thickness_m"
+    DECK_HEIGHT_LABEL = "deck_height_m"
+    DECK_HEIGHT_NETTO_LABEL = "deck_inner_height_m"
+    LENGTH_INNER_RADIUS_LABEL = "length_inner_radius_m"
+    LENGTH_OUTER_RADIUS_LABEL = "length_outer_radius_m"
+    LENGTH_OUTER_RADIUS_NETTO_LABEL = "length_outer_radius_netto_m"
+    BASE_AREA_INNER_RADIUS_LABEL = "base_area_inner_radius_m2"
+    BASE_AREA_OUTER_RADIUS_LABEL = "base_area_outer_radius_m2"
+    EFFECTIVE_VOLUME_LABEL = "effective_volume_m3"
+    NET_ROOM_VOLUME_LABEL = "net_room_volume_m3"
+    ROTATION_VELOCITY_LABEL = "rotation_velocity_mps"
+    CENTRIFUGAL_ACCELERATION_LABEL = "centrifugal_acceleration_mps2"
 
     def __init__(
         self,
@@ -194,7 +194,7 @@ class SphereDeckCalculator:
 
     def _calculate_cylindric_decks_of_a_sphere(self):
         sphere_radius = self.inner_sphere_diameter / 2
-        deck_labels = [f"{self.DECK_LABEL} {i:03}" for i in range(self.num_decks)]
+        deck_labels = [f"{self.DECK_NAME}{i:03}" for i in range(self.num_decks)]
         inner_radius = []
         outer_radius = []
         outer_radius_netto = []
@@ -271,7 +271,7 @@ class SphereDeckCalculator:
 
         df_decks = pd.DataFrame(
             {
-                self.DECK_LABEL: deck_labels,
+                self.DECK_ID_LABEL: deck_labels,
                 self.INNER_RADIUS_LABEL: inner_radius,
                 self.OUTER_RADIUS_LABEL: outer_radius,
                 self.OUTER_RADIUS_NETTO_LABEL: outer_radius_netto,
@@ -423,7 +423,7 @@ class SphereDeckCalculator:
         progress_bar = tqdm(total=frames, desc="Rendering Animation")
 
         def update(num, data, line):
-            self._setup_3D_plot(ax, f"{SphereDeckCalculator.DECK_LABEL} {num:03}")
+            self._setup_3D_plot(ax, f"{SphereDeckCalculator.DECK_NAME}{num:03}")
             for i in range(num + 1):
                 r = self.df_decks[self.OUTER_RADIUS_LABEL].iloc[i]
                 z = np.linspace(


### PR DESCRIPTION
## Summary
- rename deck dimension columns to PEP8 style
- adjust Blender csv generator and simulation scripts to use new names
- update example csv and README accordingly
- document design decisions in new `Konstruktionshandbuch`

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`
- `PYTHONPATH=. pytest -q simulations/tests/test_geometry.py`

------
https://chatgpt.com/codex/tasks/task_e_68893a08aba4832a9a14694ece0fdf49