### PR TITLE
Visualize centrifugal acceleration in Blender decks

### DIFF
--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -8,5 +8,6 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 - **Variablennamen** wurden auf ein konsistentes, PEP8‑konformes Schema umgestellt (z.B. `deck_id`, `inner_radius_m`).
 - **Blender-Skripte** erzeugen realistisch proportionierte Decks und ein zentrales Wurmloch. Materialien und Fenster werden anhand der CSV‑Daten gesetzt.
 - **Realistische Simulation**: Das Blender-Skript weist nun Materialien zu, platziert Fenster automatisch und fügt Energie- sowie Thermalsysteme wie Radiatoren, SMR und Solararrays hinzu. Lichtquellen orientieren sich an Deckfunktionen.
+- **Beschleunigungsvisualisierung**: Beim Erzeugen der Decks wird die Farbe nun aus der Zentrifugalbeschleunigung berechnet (0 m/s² → Weiß, 9.81 m/s² → Grün, höhere Werte verlaufen Richtung Rot).
 
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.


### PR DESCRIPTION
## Summary
- map centrifugal acceleration to color in `blender_deck_simulation.py`
- load `centrifugal_acceleration_mps2` from deck CSV
- use gradient colors instead of fixed grey
- document the visualization approach in the construction manual

## Testing
- `python -m py_compile simulations/blender_simulation/blender_deck_simulation.py`
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`


------
https://chatgpt.com/codex/tasks/task_e_688b3b283670832aaa0c91e28da0cf56