### PR TITLE
Add Blender launch integration

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,4 +1,6 @@
 This folder stores VS Code configuration files for launching and working with the simulation.
-The provided `launch.json` lets you run `run_simulation.py` directly from the editor,
-and `settings.json` contains defaults for previewing generated results.
+The provided `launch.json` lets you run `run_simulation.py` directly from the editor.
+It also includes a configuration `Blender Deck Simulation` which starts Blender
+via `blender_starter.py` (requires the environment variable `BLENDER_PATH`).
+`settings.json` contains defaults for previewing generated results.
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,13 @@
             "request": "launch",
             "program": "${workspaceFolder}/simulations/start_simulation/run_simulation.py",
             "console": "integratedTerminal"
+        },
+        {
+            "name": "Blender Deck Simulation",
+            "type": "python",
+            "request": "launch",
+            "program": "${workspaceFolder}/simulations/blender_simulation/blender_starter.py",
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -9,5 +9,6 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 - **Blender-Skripte** erzeugen realistisch proportionierte Decks und ein zentrales Wurmloch. Materialien und Fenster werden anhand der CSV‑Daten gesetzt.
 - **Realistische Simulation**: Das Blender-Skript weist nun Materialien zu, platziert Fenster automatisch und fügt Energie- sowie Thermalsysteme wie Radiatoren, SMR und Solararrays hinzu. Lichtquellen orientieren sich an Deckfunktionen.
 - **Beschleunigungsvisualisierung**: Beim Erzeugen der Decks wird die Farbe nun aus der Zentrifugalbeschleunigung berechnet (0 m/s² → Weiß, 9.81 m/s² → Grün, höhere Werte verlaufen Richtung Rot).
+- **Bequemer Start**: `blender_starter.py` startet Blender über die Umgebungsvariable `BLENDER_PATH`. Eine VS-Code-Launch-Konfiguration vereinfacht den Aufruf.
 
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/blender_simulation/README.md
+++ b/simulations/blender_simulation/README.md
@@ -5,6 +5,7 @@ Dieser Ordner enthält die Proof-of-Concept-Dateien für Blender, mit denen die 
 * **blender_deck_simulation.py** – Blender-Python-Skript, das Ringsegmente aus `deck_3d_construction_data.csv` erzeugt.
 * **generate_3d_construction_csv.py** – erzeugt `deck_3d_construction_data.csv` aus `../results/deck_dimensions.csv`.
 * **deck_3d_construction_data.csv** – Geometriewerte aus den Deck-Berechnungen.
+* **blender_starter.py** – Komfortskript zum Starten von Blender über die Umgebungsvariable `BLENDER_PATH`.
 * **Blender Simulation Projektplan.docx** (in `../project`) – Grobplan mit weiteren Arbeitsschritten.
 
 * **Blender Simulation Sprintplan.docx** – Aufgabenübersicht zum Aufsetzen dieses Verzeichnisses.
@@ -61,3 +62,14 @@ blender --python simulations/blender_simulation/blender_deck_simulation.py --bac
 ```
 
 Der Befehl erzeugt eine `.blend`‑Datei im Hintergrundmodus zur Weiterverarbeitung.
+
+## Ausführen mit `blender_starter.py`
+
+Setze die Umgebungsvariable `BLENDER_PATH` auf dein Blender-Executable und
+starte anschließend:
+
+```bash
+python blender_starter.py --background
+```
+
+Weitere Argumente werden direkt an Blender weitergereicht.

--- a/simulations/blender_simulation/blender_starter.py
+++ b/simulations/blender_simulation/blender_starter.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Launch Blender with the deck simulation script"
+    )
+    parser.add_argument(
+        "--blender",
+        default=os.getenv("BLENDER_PATH"),
+        help="Path to the Blender executable (or set BLENDER_PATH)",
+    )
+    parser.add_argument(
+        "--script",
+        default=os.path.join(os.path.dirname(__file__), "blender_deck_simulation.py"),
+        help="Blender Python file to execute",
+    )
+    parser.add_argument(
+        "--background", action="store_true", help="Run Blender in background mode"
+    )
+    parser.add_argument(
+        "extra",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to Blender",
+    )
+
+    args = parser.parse_args()
+
+    blender = args.blender
+    if not blender:
+        print("BLENDER_PATH not set and --blender not provided", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = [blender]
+    if args.background:
+        cmd.append("--background")
+    cmd += ["--python", args.script]
+    if args.extra:
+        cmd += args.extra
+
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend VS Code `launch.json` with "Blender Deck Simulation" entry
- document new launch entry in `.vscode/README.md`
- add `blender_starter.py` helper for launching Blender using `BLENDER_PATH`
- mention new helper in Blender simulation README
- record convenience script in Konstruktionshandbuch

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`

------
https://chatgpt.com/codex/tasks/task_e_688b3f911058832a85a3c9df721925ea