### PR TITLE
Add Blender hull simulation starter

### DIFF
--- a/.vscode/README.md
+++ b/.vscode/README.md
@@ -1,6 +1,6 @@
 This folder stores VS Code configuration files for launching and working with the simulation.
 The provided `launch.json` lets you run `run_simulation.py` directly from the editor.
-It also includes a configuration `Blender Deck Simulation` which starts Blender
-via `blender_starter.py` (requires the environment variable `BLENDER_PATH`).
+It also includes configurations `Blender Deck Simulation` and `Blender Hull Simulation` which start Blender
+via their respective `blender_starter.py` scripts (requires the environment variable `BLENDER_PATH`).
 `settings.json` contains defaults for previewing generated results.
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,17 @@
                 "--blender",
                 "C:/Program Files/Blender Foundation/Blender 4.5/blender.exe",
             ],
+        },
+        {
+            "name": "Blender Hull Simulation",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/simulations/blender_hull_simulation/blender_starter.py",
+            "console": "integratedTerminal",
+            "args": [
+                "--blender",
+                "C:/Program Files/Blender Foundation/Blender 4.5/blender.exe",
+            ],
         }
     ]
 }

--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -10,5 +10,6 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 - **Realistische Simulation**: Das Blender-Skript weist nun Materialien zu, platziert Fenster automatisch und fügt Energie- sowie Thermalsysteme wie Radiatoren, SMR und Solararrays hinzu. Lichtquellen orientieren sich an Deckfunktionen.
 - **Beschleunigungsvisualisierung**: Beim Erzeugen der Decks wird die Farbe nun aus der Zentrifugalbeschleunigung berechnet (0 m/s² → Weiß, 9.81 m/s² → Grün, höhere Werte verlaufen Richtung Rot).
 - **Bequemer Start**: `blender_starter.py` startet Blender über die Umgebungsvariable `BLENDER_PATH`. Eine VS-Code-Launch-Konfiguration vereinfacht den Aufruf.
+- **Hüllensimulation**: Ein weiteres Skript `blender_hull_simulator.py` erzeugt eine vereinfachte Außenhülle. Über einen eigenen VS‑Code-Starteintrag kann das Skript bequem getestet werden.
 
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/README.md
+++ b/simulations/README.md
@@ -4,4 +4,6 @@ This folder hosts example scripts and data used to generate visualizations for t
 
 The `scripts` subdirectory contains the Python module `deck_calculations_script.py`, which builds geometry for the rotating sphere station and renders animations.
 
+`blender_simulation` and `blender_hull_simulation` provide example Blender scripts for visualizing the decks and the outer hull respectively.
+
 Simulation code is provided under the MIT license for educational purposes. Refer to `LICENSE-MIT` for details. Other content within this repository may be subject to the proprietary license described in the root `README.md`.

--- a/simulations/blender_hull_simulation/README.md
+++ b/simulations/blender_hull_simulation/README.md
@@ -1,0 +1,6 @@
+# Blender Hull Simulation
+
+This folder contains a minimal Blender Python script that generates a simple hull model for the Sphere Station. It mirrors the approach of the deck simulation but focuses solely on the outer hull.
+
+* **blender_hull_simulator.py** – Creates a basic hull based on `deck_3d_construction_data.csv`.
+* **blender_starter.py** – Convenience launcher that starts Blender using the environment variable `BLENDER_PATH`.

--- a/simulations/blender_hull_simulation/blender_hull_simulator.py
+++ b/simulations/blender_hull_simulation/blender_hull_simulator.py
@@ -1,0 +1,40 @@
+"""blender_hull_simulator.py
+A minimal Blender script that creates a simplified hull based on the
+`deck_3d_construction_data.csv` file.
+
+Run this script inside Blender or from the command line with
+``blender --python blender_hull_simulator.py``.
+"""
+
+import csv
+import os
+import bpy
+
+
+def load_outer_radius(csv_path: str) -> float:
+    with open(csv_path, newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        if not rows:
+            raise ValueError("CSV contains no deck data")
+        outer = float(rows[-1]["outer_radius_m"])
+        return outer
+
+
+def create_hull(radius: float) -> None:
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=False)
+    bpy.ops.mesh.primitive_uv_sphere_add(radius=radius, enter_editmode=False)
+
+
+def main() -> None:
+    script_dir = os.path.dirname(__file__)
+    csv_path = os.path.join(script_dir, "deck_3d_construction_data.csv")
+    if not os.path.exists(csv_path):
+        raise FileNotFoundError(csv_path)
+    radius = load_outer_radius(csv_path)
+    create_hull(radius)
+
+
+if __name__ == "__main__":
+    main()

--- a/simulations/blender_hull_simulation/blender_starter.py
+++ b/simulations/blender_hull_simulation/blender_starter.py
@@ -1,0 +1,48 @@
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Launch Blender with the hull simulation script"
+    )
+    parser.add_argument(
+        "--blender",
+        default=os.getenv("BLENDER_PATH"),
+        help="Path to the Blender executable (or set BLENDER_PATH)",
+    )
+    parser.add_argument(
+        "--script",
+        default=os.path.join(os.path.dirname(__file__), "blender_hull_simulator.py"),
+        help="Blender Python file to execute",
+    )
+    parser.add_argument(
+        "--background", action="store_true", help="Run Blender in background mode"
+    )
+    parser.add_argument(
+        "extra",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to Blender",
+    )
+
+    args = parser.parse_args()
+
+    blender = args.blender
+    if not blender:
+        print("BLENDER_PATH not set and --blender not provided", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = [blender]
+    if args.background:
+        cmd.append("--background")
+    cmd += ["--python", args.script]
+    if args.extra:
+        cmd += args.extra
+
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/simulations/blender_hull_simulation/deck_3d_construction_data.csv
+++ b/simulations/blender_hull_simulation/deck_3d_construction_data.csv
@@ -1,0 +1,17 @@
+deck_id,deck_usage,inner_radius_m,outer_radius_m,outer_radius_netto_m,deck_height_m,deck_inner_height_m,num_windows,window_material,window_thickness_cm,structure_material,rotation_velocity_mps,centrifugal_acceleration_mps2
+Deck 000,Docking & Command Center,0.0,10.5,10.0,10.5,10.0,6,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,5.0,2.5
+Deck 001,Residential/Operational,10.5,14.0,13.5,3.5,3.0,8,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,6.75,3.375
+Deck 002,Residential/Operational,14.0,17.5,17.0,3.5,3.0,10,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,8.5,4.25
+Deck 003,Residential/Operational,17.5,21.0,20.5,3.5,3.0,12,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,10.25,5.125
+Deck 004,Residential/Operational,21.0,24.5,24.0,3.5,3.0,15,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,12.0,6.0
+Deck 005,Residential/Operational,24.5,28.0,27.5,3.5,3.0,17,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,13.75,6.875
+Deck 006,Residential/Operational,28.0,31.5,31.0,3.5,3.0,19,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,15.5,7.75
+Deck 007,Residential/Operational,31.5,35.0,34.5,3.5,3.0,21,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,17.25,8.625
+Deck 008,Industrial/Recreational,35.0,38.5,38.0,3.5,3.0,23,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,19.0,9.5
+Deck 009,Industrial/Recreational,38.5,42.0,41.5,3.5,3.0,26,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,20.75,10.375
+Deck 010,Industrial/Recreational,42.0,45.5,45.0,3.5,3.0,28,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,22.5,11.25
+Deck 011,Industrial/Recreational,45.5,49.0,48.5,3.5,3.0,30,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,24.25,12.125
+Deck 012,Industrial/Recreational,49.0,52.5,52.0,3.5,3.0,32,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,26.0,13.0
+Deck 013,Storage/Propulsion,52.5,56.0,55.5,3.5,3.0,34,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,27.75,13.875
+Deck 014,Storage/Propulsion,56.0,59.5,59.0,3.5,3.0,37,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,29.5,14.75
+Deck 015,Storage/Propulsion,59.5,63.0,62.5,3.5,3.0,39,ALON + Fused Silica + Polycarbonate + Borosilicate,20,Silicon Carbide Composite + Silicon Elastomer,31.25,15.625


### PR DESCRIPTION
## Summary
- add `blender_hull_simulation` directory with starter and hull script
- expand VS Code launch configuration for new hull simulator
- document new setup in `.vscode/README.md` and `simulations/README.md`
- record hull simulator in `Konstruktionshandbuch`

## Testing
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `black --check simulations/scripts/deck_calculations_script.py`
- `PYTHONPATH=. pytest -q simulations/tests simulations/unit_tests`

------
https://chatgpt.com/codex/tasks/task_e_688b77e23d1c832a9a1ec14d87c24a14