### PR TITLE
Add deck calculator starter script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,13 @@
             "console": "integratedTerminal"
         },
         {
+            "name": "Deck Calculator Starter",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/simulations/scripts/dec_calculator_starter.py",
+            "console": "integratedTerminal"
+        },
+        {
             "name": "Blender Deck Simulation",
             "type": "debugpy",
             "request": "launch",

--- a/simulations/scripts/dec_calculator_starter.py
+++ b/simulations/scripts/dec_calculator_starter.py
@@ -1,0 +1,44 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from simulations.scripts.deck_calculations_adapter import SphereDeckCalculator
+
+
+def main() -> None:
+    calculator = SphereDeckCalculator(
+        "Deck Dimensions of a Sphere",
+        sphere_diameter=127.0,
+        hull_thickness=0.5,
+        windows_per_deck_ratio=0.20,
+        num_decks=16,
+        deck_000_outer_radius=10.5,
+        deck_height_brutto=3.5,
+        deck_ceiling_thickness=0.5,
+    )
+
+    calculator.calculate_dynamics_of_a_sphere(angular_velocity=0.5)
+    print(calculator.to_string())
+    calculator.to_csv("deck_dimensions.csv")
+    calculator.to_html("deck_dimensions.html")
+    calculator.to_3D_animation_show_all_decks("deck_animation.html")
+    calculator.to_3D_animation_rotate_all_decks("deck_animation_rotate.html")
+    calculator.to_3D_animation_rotate_hull_with_windows(
+        "hull_with_windows_animation.html",
+        frames=25,
+        frames_per_second=5,
+        rotation_axis="Z",
+    )
+    calculator.to_3D_animation_rotate_hull("hull_animation.html")
+    calculator.to_3D_animation_rotate_hull_with_gravity_zones(
+        "hull_with_gravity_zones_animation.html",
+        frames=25,
+        frames_per_second=25,
+        rotation_axis="Z",
+        show_gravity_zones=False,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `dec_calculator_starter.py` to drive the deck calculations adapter and produce animations
- include new VS Code launch configuration for running the starter script

## Testing
- `black --check simulations/scripts/deck_calculations_script.py`
- `python -m py_compile simulations/scripts/deck_calculations_script.py`
- `python -m py_compile simulations/scripts/dec_calculator_starter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b7ed14a10832a90688eaf0bdc8f8c