### PR TITLE
Apply Black formatting to simulation utilities

### DIFF
--- a/simulations/sphere_space_station_simulations/blender_helpers/__init__.py
+++ b/simulations/sphere_space_station_simulations/blender_helpers/__init__.py
@@ -35,7 +35,9 @@ def move_to_collection(obj: bpy.types.Object, collection: bpy.types.Collection) 
             coll.objects.unlink(obj)
 
 
-def get_or_create_material(name: str, color: tuple[float, float, float, float]) -> bpy.types.Material:
+def get_or_create_material(
+    name: str, color: tuple[float, float, float, float]
+) -> bpy.types.Material:
     """Return existing material or create a new one with the given RGBA color."""
     if name in bpy.data.materials:
         return bpy.data.materials[name]
@@ -47,7 +49,9 @@ def get_or_create_material(name: str, color: tuple[float, float, float, float]) 
     return mat
 
 
-def assign_material(obj: bpy.types.Object, material_name: str, color: tuple[float, float, float, float]) -> None:
+def assign_material(
+    obj: bpy.types.Object, material_name: str, color: tuple[float, float, float, float]
+) -> None:
     """Assign material to the given object."""
     mat = get_or_create_material(material_name, color)
     if obj.data.materials:
@@ -82,7 +86,9 @@ def create_window_strip(
         move_to_collection(win, collection)
 
 
-def create_radiator(radius_m: float, length_m: float, width_m: float, angle_deg: float, name: str) -> bpy.types.Object:
+def create_radiator(
+    radius_m: float, length_m: float, width_m: float, angle_deg: float, name: str
+) -> bpy.types.Object:
     """Create a simple radiator panel."""
     bpy.ops.mesh.primitive_plane_add(size=1.0, location=(radius_m, 0.0, 0.0))
     panel = bpy.context.active_object
@@ -92,7 +98,9 @@ def create_radiator(radius_m: float, length_m: float, width_m: float, angle_deg:
     return panel
 
 
-def create_solar_array(radius_m: float, length_m: float, width_m: float, angle_deg: float, name: str) -> bpy.types.Object:
+def create_solar_array(
+    radius_m: float, length_m: float, width_m: float, angle_deg: float, name: str
+) -> bpy.types.Object:
     """Create a simple solar array panel."""
     bpy.ops.mesh.primitive_plane_add(size=1.0, location=(radius_m, 0.0, 0.0))
     panel = bpy.context.active_object
@@ -104,7 +112,9 @@ def create_solar_array(radius_m: float, length_m: float, width_m: float, angle_d
 
 def create_smr(height_m: float, radius_m: float) -> bpy.types.Object:
     """Create a simplified small modular reactor cylinder."""
-    bpy.ops.mesh.primitive_cylinder_add(radius=radius_m, depth=height_m, location=(0.0, 0.0, -height_m / 2.0))
+    bpy.ops.mesh.primitive_cylinder_add(
+        radius=radius_m, depth=height_m, location=(0.0, 0.0, -height_m / 2.0)
+    )
     smr = bpy.context.active_object
     smr.name = "SMR"
     return smr
@@ -118,7 +128,9 @@ def create_rotation_controller() -> bpy.types.Object:
     return ctrl
 
 
-def add_light(name: str, location: tuple[float, float, float], energy: float = 1000.0) -> bpy.types.Object:
+def add_light(
+    name: str, location: tuple[float, float, float], energy: float = 1000.0
+) -> bpy.types.Object:
     """Add a point light to the scene."""
     bpy.ops.object.light_add(type="POINT", location=location)
     light = bpy.context.active_object
@@ -135,10 +147,16 @@ def create_ring_deck(
     name: str,
 ) -> bpy.types.Object:
     """Construct a hollow cylindrical shell using boolean difference."""
-    bpy.ops.mesh.primitive_cylinder_add(radius=outer_radius_m, depth=deck_height_m, location=(0.0, 0.0, z_center_m))
+    bpy.ops.mesh.primitive_cylinder_add(
+        radius=outer_radius_m, depth=deck_height_m, location=(0.0, 0.0, z_center_m)
+    )
     outer = bpy.context.active_object
     outer.name = f"{name}_outer"
-    bpy.ops.mesh.primitive_cylinder_add(radius=inner_radius_m, depth=deck_height_m + 0.05, location=(0.0, 0.0, z_center_m))
+    bpy.ops.mesh.primitive_cylinder_add(
+        radius=inner_radius_m,
+        depth=deck_height_m + 0.05,
+        location=(0.0, 0.0, z_center_m),
+    )
     inner = bpy.context.active_object
     inner.name = f"{name}_inner"
     boolean_mod = outer.modifiers.new(name="Boolean", type="BOOLEAN")
@@ -154,21 +172,28 @@ def create_ring_deck(
 
 def create_wormhole(radius_m: float, total_height_m: float) -> bpy.types.Object:
     """Create the central wormhole cylinder running through all decks."""
-    bpy.ops.mesh.primitive_cylinder_add(radius=radius_m, depth=total_height_m, location=(0.0, 0.0, 0.0))
+    bpy.ops.mesh.primitive_cylinder_add(
+        radius=radius_m, depth=total_height_m, location=(0.0, 0.0, 0.0)
+    )
     wormhole = bpy.context.active_object
     wormhole.name = "Wormhole"
     return wormhole
 
 
-def create_base_rings(wormhole_radius_m: float, base_thickness_m: float, total_height_m: float) -> list:
+def create_base_rings(
+    wormhole_radius_m: float, base_thickness_m: float, total_height_m: float
+) -> list:
     """Create upper and lower base rings at the ends of the wormhole."""
     base_radius = wormhole_radius_m * 1.2
     rings = []
     half = total_height_m / 2.0
-    for i, z_pos in enumerate([half + base_thickness_m / 2.0, -(half + base_thickness_m / 2.0)]):
-        bpy.ops.mesh.primitive_cylinder_add(radius=base_radius, depth=base_thickness_m, location=(0.0, 0.0, z_pos))
+    for i, z_pos in enumerate(
+        [half + base_thickness_m / 2.0, -(half + base_thickness_m / 2.0)]
+    ):
+        bpy.ops.mesh.primitive_cylinder_add(
+            radius=base_radius, depth=base_thickness_m, location=(0.0, 0.0, z_pos)
+        )
         ring = bpy.context.active_object
         ring.name = f"BaseRing_{'Top' if i == 0 else 'Bottom'}"
         rings.append(ring)
     return rings
-

--- a/simulations/sphere_space_station_simulations/data_preparation.py
+++ b/simulations/sphere_space_station_simulations/data_preparation.py
@@ -30,7 +30,9 @@ STRUCTURE_MATERIAL = "Silicon Carbide Composite + Silicon Elastomer"
 WINDOW_THICKNESS_CM = 20
 
 
-def generate_deck_construction_csv(input_csv: str | Path, output_csv: str | Path) -> Path:
+def generate_deck_construction_csv(
+    input_csv: str | Path, output_csv: str | Path
+) -> Path:
     """Generate a CSV with additional deck metadata for Blender.
 
     Parameters
@@ -80,4 +82,3 @@ def generate_deck_construction_csv(input_csv: str | Path, output_csv: str | Path
     output_csv.parent.mkdir(parents=True, exist_ok=True)
     df[cols].to_csv(output_csv, index=False)
     return output_csv
-

--- a/simulations/sphere_space_station_simulations/geometry/deck.py
+++ b/simulations/sphere_space_station_simulations/geometry/deck.py
@@ -94,7 +94,6 @@ class SphereDeckCalculator:
         self.animation_writers = animation.writers.list()
         self.selected_animation_writer = None
 
-
     def _calculate_window_geometry(self):
         """Calculate the geometry of windows for each deck and store in a dictionary."""
         window_geometry = {}  # Dictionary to store window coordinates for each deck


### PR DESCRIPTION
## Summary
- format `blender_helpers`, `data_preparation`, and `geometry/deck` with Black

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d3eabe14c832ab4eaedc184789e4b