### PR TITLE
Fix launcher scripts path

### DIFF
--- a/simulations/blender_deck_simulator/starter.py
+++ b/simulations/blender_deck_simulator/starter.py
@@ -1,9 +1,15 @@
 import argparse
 from pathlib import Path
-from simulations.sphere_space_station_simulations.data_preparation import generate_deck_construction_csv
 import os
 import subprocess
 import sys
+
+# Allow running without installing the package
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from simulations.sphere_space_station_simulations.data_preparation import (
+    generate_deck_construction_csv,
+)
 
 
 def main() -> None:
@@ -33,7 +39,6 @@ def main() -> None:
     input_csv = Path(__file__).resolve().parents[1] / "results" / "deck_dimensions.csv"
     output_csv = Path(__file__).resolve().parent / "deck_3d_construction_data.csv"
     generate_deck_construction_csv(input_csv, output_csv)
-
 
     blender = args.blender
     if not blender:

--- a/simulations/deck_calculator/starter.py
+++ b/simulations/deck_calculator/starter.py
@@ -1,3 +1,9 @@
+import os
+import sys
+
+# Allow execution without installing the package by adding the repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
 from simulations.sphere_space_station_simulations import SphereDeckCalculator
 
 


### PR DESCRIPTION
## Summary
- fix Python path in deck calculator starter
- fix Python path in Blender deck simulator starter
- run programmatic checks

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `python simulations/blender_station_simulator/starter.py`
- `python simulations/deck_calculator/starter.py` *(interrupted after verifying launch)*
- `python simulations/blender_deck_simulator/starter.py --blender /tmp/blender.exe`
- `python simulations/blender_hull_simulation/starter.py --blender /tmp/blender.exe`

------
https://chatgpt.com/codex/tasks/task_e_688d4d50f888832a835e6170fd43cb08