### PR TITLE
Fix Blender adapter import path

### DIFF
--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -18,5 +18,8 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 - **Stationssimulation** ist in `simulation.py` umgezogen und kann direkt aus der
   Bibliothek gestartet werden. `run_simulation.py` heißt nun `starter.py`.
 
+- **Importpfad**: `adapter.py` fügt das Repository-Root dem `sys.path` hinzu,
+  wodurch Blender die Hilfsfunktionen korrekt findet.
+
 
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/blender_deck_simulator/adapter.py
+++ b/simulations/blender_deck_simulator/adapter.py
@@ -73,7 +73,11 @@ add modifiers within Blender.
 import csv
 import os
 import math
+import sys
 import bpy
+
+# Allow running without installing the package
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
 
 from simulations.sphere_space_station_simulations.blender_helpers import (
     acceleration_to_color,


### PR DESCRIPTION
## Summary
- ensure Blender adapter adds project root to `sys.path`
- document adapter import path change in construction handbook

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest simulations/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688df918abbc832a94f9baf8fcc15c56