### PR TITLE
Fix hull starter and drop pandas dependency

### DIFF
--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -21,5 +21,8 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 - **Importpfad**: `adapter.py` fügt das Repository-Root dem `sys.path` hinzu,
   wodurch Blender die Hilfsfunktionen korrekt findet.
 
+- **Abhängigkeiten reduziert**: `generate_deck_construction_csv` kommt ohne Pandas aus und das Paket nutzt Lazy‑Imports, sodass die Blender‑Adapter ohne zusätzliche Bibliotheken laufen.
+- **Hull-Starter**: `starter.py` der Hüllensimulation verweist nun standardmäßig auf `adapter.py`.
+
 
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/blender_hull_simulation/adapter.py
+++ b/simulations/blender_hull_simulation/adapter.py
@@ -1,9 +1,9 @@
-"""blender_hull_simulator.py
+"""adapter.py
 A minimal Blender script that creates a simplified hull based on the
 `deck_3d_construction_data.csv` file.
 
 Run this script inside Blender or from the command line with
-``blender --python blender_hull_simulator.py``.
+``blender --python adapter.py``.
 """
 
 import csv

--- a/simulations/blender_hull_simulation/starter.py
+++ b/simulations/blender_hull_simulation/starter.py
@@ -15,7 +15,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--script",
-        default=os.path.join(os.path.dirname(__file__), "blender_hull_simulator.py"),
+        default=os.path.join(os.path.dirname(__file__), "adapter.py"),
         help="Blender Python file to execute",
     )
     parser.add_argument(

--- a/simulations/sphere_space_station_simulations/__init__.py
+++ b/simulations/sphere_space_station_simulations/__init__.py
@@ -1,7 +1,26 @@
 """Core simulation package for the Sphere Station."""
 
-from .geometry.deck import SphereDeckCalculator
-from .simulation import StationSimulation
-from .geometry.hull import calculate_hull_geometry
+from typing import TYPE_CHECKING
 
 __all__ = ["SphereDeckCalculator", "StationSimulation", "calculate_hull_geometry"]
+
+if TYPE_CHECKING:  # pragma: no cover - for type checkers only
+    from .geometry.deck import SphereDeckCalculator
+    from .simulation import StationSimulation
+    from .geometry.hull import calculate_hull_geometry
+
+
+def __getattr__(name: str):
+    if name == "SphereDeckCalculator":
+        from .geometry.deck import SphereDeckCalculator
+
+        return SphereDeckCalculator
+    if name == "StationSimulation":
+        from .simulation import StationSimulation
+
+        return StationSimulation
+    if name == "calculate_hull_geometry":
+        from .geometry.hull import calculate_hull_geometry
+
+        return calculate_hull_geometry
+    raise AttributeError(f"module {__name__!r} has no attribute {name}")


### PR DESCRIPTION
## Summary
- point hull `starter.py` at the existing `adapter.py`
- load simulation helpers lazily and generate construction CSV using the standard library
- rewrite tests to avoid pandas and document reduced dependencies

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py simulations/blender_hull_simulation/starter.py simulations/blender_hull_simulation/adapter.py simulations/sphere_space_station_simulations/__init__.py simulations/sphere_space_station_simulations/data_preparation.py simulations/tests/test_blender_csv.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688dfc705ab4832aa4e1559e983c8bbf