### PR TITLE
Ensure Blender deck simulation renders all decks

### DIFF
--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -24,5 +24,10 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 - **Abhängigkeiten reduziert**: `generate_deck_construction_csv` kommt ohne Pandas aus und das Paket nutzt Lazy‑Imports, sodass die Blender‑Adapter ohne zusätzliche Bibliotheken laufen.
 - **Hull-Starter**: `starter.py` der Hüllensimulation verweist nun standardmäßig auf `adapter.py`.
 
+- **Deck-Rendering**: `create_ring_deck` entfernt nur noch die innere Hilfsgeometrie,
+  sodass alle Decks statt nur des Wurmlochs erscheinen. Die Deck-ID wird
+  nun anhand des Unterstrichs korrekt ausgewertet, damit Fenster für die ersten
+  zwölf Decks erzeugt werden.
+
 
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/blender_deck_simulator/adapter.py
+++ b/simulations/blender_deck_simulator/adapter.py
@@ -97,8 +97,6 @@ from simulations.sphere_space_station_simulations.blender_helpers import (
 )
 
 
-
-
 def load_deck_data(csv_path: str) -> list:
     """Load deck information from a CSV file.
 
@@ -177,7 +175,7 @@ def main():
         assign_material(obj, deck["structure_material"], color)
 
         # Create windows up to Deck 012
-        if int(deck["deck_id"].split()[1]) <= 12:
+        if int(deck["deck_id"].split("_")[1]) <= 12:
             create_window_strip(
                 deck_radius_m=deck["outer_radius_netto_m"],
                 window_thickness_cm=deck["window_thickness_cm"],

--- a/simulations/sphere_space_station_simulations/blender_helpers/__init__.py
+++ b/simulations/sphere_space_station_simulations/blender_helpers/__init__.py
@@ -164,8 +164,7 @@ def create_ring_deck(
     boolean_mod.operation = "DIFFERENCE"
     bpy.context.view_layer.objects.active = outer
     bpy.ops.object.modifier_apply(modifier=boolean_mod.name)
-    inner.select_set(True)
-    bpy.ops.object.delete()
+    bpy.data.objects.remove(inner, do_unlink=True)
     outer.name = name
     return outer
 


### PR DESCRIPTION
## Summary
- fix `create_ring_deck` so only the inner helper cylinder is removed, allowing deck geometry to remain
- parse deck IDs with underscores to generate windows for the first twelve decks
- document the deck-rendering fix in the construction handbook

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest simulations/tests`


------
https://chatgpt.com/codex/tasks/task_e_688dffeba140832ab3353233e820480f