### PR TITLE
feat: add sprint 1 architecture and exporter prototypes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentation
+
+This directory contains supplementary documentation for the project.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,3 @@
+# Architecture Documentation
+
+This folder hosts design notes for the STEP/glTF integration and CAD detail work.

--- a/docs/architecture/layered_architecture.md
+++ b/docs/architecture/layered_architecture.md
@@ -1,0 +1,13 @@
+# Schichtmodell
+
+```
+KERNEL  -> berechnet Geometrie und Simulationen
+  |
+  v
+ADAPTER -> exportiert Datenformate (STEP, glTF, JSON)
+  |
+  v
+GUI     -> Anwendungen wie Blender oder Web-Viewer
+```
+
+Der KERNEL enthält die Berechnungslogik. ADAPTER wandeln interne Datenmodelle in Austauschformate. GUI-Schichten konsumieren nur diese Formate und halten keine eigene Logik vor.

--- a/docs/architecture/library_evaluation.md
+++ b/docs/architecture/library_evaluation.md
@@ -1,0 +1,29 @@
+# Bibliotheks-Research: STEP- und glTF-Erzeugung
+
+## STEP-Bibliotheken
+
+### pythonocc-core
+- Lizenz: LGPL/GPL
+- Stärken: mächtige CAD-Kernel-Funktionen, weit verbreitet
+- Schwächen: große Abhängigkeiten, steile Lernkurve
+
+### CadQuery
+- Lizenz: Apache-2.0
+- Stärken: Pythonic API, integrierte Exportfunktionen (STEP, STL)
+- Schwächen: weniger direkte Kontrolle über B-Rep-Details
+
+**Entscheidung:** Für Prototypen wird `CadQuery` bevorzugt, da es eine leichtere API bietet und STEP-Export out-of-the-box unterstützt.
+
+## glTF-Bibliotheken
+
+### pygltflib
+- Lizenz: MIT
+- Stärken: schlanke Bibliothek, direkte Kontrolle über glTF-Strukturen
+- Schwächen: wenig Komfortfunktionen für Mesh-Generierung
+
+### trimesh
+- Lizenz: MIT
+- Stärken: hohe Abdeckung an 3D-Formaten, einfache Mesh-Erstellung
+- Schwächen: größere Abhängigkeiten
+
+**Entscheidung:** `trimesh` wird genutzt, um primitive Geometrien zu erzeugen und anschließend nach glTF zu exportieren.

--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -30,4 +30,8 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
   zwölf Decks erzeugt werden.
 
 
+- **Schichtmodell**: KERNEL, ADAPTER und GUI wurden als klare Ebenen definiert.
+- **Datenmodell**: Dataclasses für Decks und Hülle ermöglichen den Export.
+- **Prototyp-Exporter**: Erste STEP- und glTF-Dateien werden aus den Datenobjekten generiert.
+
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/sphere_space_station_simulations/adapters/README.md
+++ b/simulations/sphere_space_station_simulations/adapters/README.md
@@ -1,0 +1,3 @@
+# Adapters
+
+Prototype exporters translating internal geometry data into external formats.

--- a/simulations/sphere_space_station_simulations/adapters/gltf_exporter.py
+++ b/simulations/sphere_space_station_simulations/adapters/gltf_exporter.py
@@ -1,0 +1,27 @@
+"""Prototype glTF exporter.
+
+Creates a trivial glTF 2.0 file containing metadata about decks and hull.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..data_model import StationModel
+
+
+def export_gltf(model: StationModel, filepath: str | Path) -> Path:
+    """Write a minimal glTF file with station metadata."""
+
+    path = Path(filepath)
+    data = {
+        "asset": {"version": "2.0"},
+        "extras": {
+            "deck_count": len(model.decks),
+            "has_hull": model.hull is not None,
+        },
+    }
+    with path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+    return path

--- a/simulations/sphere_space_station_simulations/adapters/step_exporter.py
+++ b/simulations/sphere_space_station_simulations/adapters/step_exporter.py
@@ -1,0 +1,41 @@
+"""Prototype STEP exporter.
+
+Writes a very small placeholder STEP file describing decks and hull radius.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from ..data_model import Hull, StationModel
+
+HEADER = "ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\n"
+FOOTER = "ENDSEC;\nEND-ISO-10303-21;\n"
+
+
+def _iter_lines(model: StationModel) -> Iterable[str]:
+    for deck in model.decks:
+        yield f"/* deck {deck.id} */\n"
+    if model.hull:
+        yield f"/* hull radius {model.hull.radius_m} */\n"
+
+
+def export_step(model: StationModel, filepath: str | Path) -> Path:
+    """Write a minimal STEP file.
+
+    Parameters
+    ----------
+    model: StationModel
+        Geometry to export.
+    filepath: str | Path
+        Output filename.
+    """
+
+    path = Path(filepath)
+    with path.open("w", encoding="utf-8") as fh:
+        fh.write(HEADER)
+        for line in _iter_lines(model):
+            fh.write(line)
+        fh.write(FOOTER)
+    return path

--- a/simulations/sphere_space_station_simulations/data_model.py
+++ b/simulations/sphere_space_station_simulations/data_model.py
@@ -1,0 +1,31 @@
+"""Data transfer objects for geometry exchange."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass
+class Deck:
+    """Cylinder-shaped deck of the station."""
+
+    id: int
+    inner_radius_m: float
+    outer_radius_m: float
+    height_m: float
+
+
+@dataclass
+class Hull:
+    """Simple spherical hull description."""
+
+    radius_m: float
+
+
+@dataclass
+class StationModel:
+    """Container aggregating all geometry elements."""
+
+    decks: List[Deck] = field(default_factory=list)
+    hull: Optional[Hull] = None

--- a/simulations/tests/test_adapters.py
+++ b/simulations/tests/test_adapters.py
@@ -1,0 +1,33 @@
+"""Tests for STEP and glTF prototype exporters."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+
+from pathlib import Path
+
+from simulations.sphere_space_station_simulations.adapters.gltf_exporter import (
+    export_gltf,
+)
+from simulations.sphere_space_station_simulations.adapters.step_exporter import (
+    export_step,
+)
+from simulations.sphere_space_station_simulations.data_model import (
+    Deck,
+    Hull,
+    StationModel,
+)
+
+
+def test_exporters_create_files(tmp_path: Path) -> None:
+    model = StationModel(decks=[Deck(1, 1.0, 2.0, 3.0)], hull=Hull(10.0))
+
+    step_file = export_step(model, tmp_path / "station.step")
+    gltf_file = export_gltf(model, tmp_path / "station.gltf")
+
+    assert step_file.exists()
+    assert gltf_file.exists()
+    assert "deck 1" in step_file.read_text()
+    assert '"deck_count": 1' in gltf_file.read_text()


### PR DESCRIPTION
## Summary
- document STEP and glTF library evaluation and propose a layered KERNEL/ADAPTER/GUI architecture
- introduce simple data model and prototype STEP/glTF exporters with unit tests
- record design decisions in the construction handbook

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/data_model.py simulations/sphere_space_station_simulations/adapters/step_exporter.py simulations/sphere_space_station_simulations/adapters/gltf_exporter.py simulations/tests/test_adapters.py`
- `pytest simulations/tests/test_adapters.py`


------
https://chatgpt.com/codex/tasks/task_e_688e301a9a00832a9ea9409e0200de8d