### PR TITLE
Add geometric details and window specs to data model

### DIFF
--- a/documents/Konstruktionshandbuch.md
+++ b/documents/Konstruktionshandbuch.md
@@ -36,4 +36,8 @@ Dieses Handbuch sammelt wichtige Entscheidungen zur Modellierung der Sphere Spac
 
 - **CLI-Exporter**: Starter-Skripte unterstützen nun `--export-step`, `--export-gltf` und `--export-json` zum Ablegen von Geometrie-Dateien; CSV bleibt als Reporting-Ausgabe.
 
+- **Detailreiches Datenmodell**: `Deck` und `Hull` enthalten Netto-Radien,
+  Zylinderlängen, Basisflächen sowie Volumina und unterstützen verschachtelte
+  Fensterangaben (Position, Größe, Anzahl).
+
 Weitere Anpassungen und Releases werden in diesem Dokument ergänzt.

--- a/simulations/sphere_space_station_simulations/data_model.py
+++ b/simulations/sphere_space_station_simulations/data_model.py
@@ -1,9 +1,24 @@
-"""Data transfer objects for geometry exchange."""
+"""Data transfer objects for geometry exchange.
+
+The models capture derived geometric metrics such as net radii, cylinder
+lengths, base areas and volumes.  Window specifications with position,
+size and count can be attached to decks or the hull.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import List, Optional, Tuple
+import math
+
+
+@dataclass
+class Window:
+    """Description of a window group."""
+
+    position: Tuple[float, float, float]
+    size_m: float
+    count: int = 1
 
 
 @dataclass
@@ -14,6 +29,33 @@ class Deck:
     inner_radius_m: float
     outer_radius_m: float
     height_m: float
+    windows: List[Window] = field(default_factory=list)
+    net_inner_radius_m: Optional[float] = None
+    net_outer_radius_m: Optional[float] = None
+    net_height_m: Optional[float] = None
+    base_area_m2: Optional[float] = None
+    volume_m3: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        self.net_inner_radius_m = (
+            self.inner_radius_m
+            if self.net_inner_radius_m is None
+            else self.net_inner_radius_m
+        )
+        self.net_outer_radius_m = (
+            self.outer_radius_m
+            if self.net_outer_radius_m is None
+            else self.net_outer_radius_m
+        )
+        self.net_height_m = (
+            self.height_m if self.net_height_m is None else self.net_height_m
+        )
+        if self.base_area_m2 is None:
+            self.base_area_m2 = math.pi * (
+                self.net_outer_radius_m**2 - self.net_inner_radius_m**2
+            )
+        if self.volume_m3 is None:
+            self.volume_m3 = self.base_area_m2 * self.net_height_m
 
 
 @dataclass
@@ -21,6 +63,19 @@ class Hull:
     """Simple spherical hull description."""
 
     radius_m: float
+    windows: List[Window] = field(default_factory=list)
+    net_radius_m: Optional[float] = None
+    surface_area_m2: Optional[float] = None
+    volume_m3: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        self.net_radius_m = (
+            self.radius_m if self.net_radius_m is None else self.net_radius_m
+        )
+        if self.surface_area_m2 is None:
+            self.surface_area_m2 = 4 * math.pi * self.net_radius_m**2
+        if self.volume_m3 is None:
+            self.volume_m3 = (4 / 3) * math.pi * self.net_radius_m**3
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- extend deck and hull data classes with net geometry metrics, derived areas and volumes
- introduce window specification data class and nested window lists
- document enriched geometry model in construction handbook

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest simulations/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_688e49e41170832ab1799c621a8eeff1