### PR TITLE
feat: export station model as JSON

### DIFF
--- a/simulations/sphere_space_station_simulations/adapters/__init__.py
+++ b/simulations/sphere_space_station_simulations/adapters/__init__.py
@@ -1,0 +1,16 @@
+"""Exporter helpers for the station model.
+
+The package exposes convenience functions to serialise a
+:class:`~simulations.sphere_space_station_simulations.data_model.StationModel`
+into a range of external formats:
+
+* :func:`export_step` – STEP B-Rep files
+* :func:`export_gltf` – glTF meshes with an animation
+* :func:`export_json` – plain JSON representation
+"""
+
+from .gltf_exporter import export_gltf
+from .step_exporter import export_step
+from .json_exporter import export_json
+
+__all__ = ["export_gltf", "export_step", "export_json"]

--- a/simulations/sphere_space_station_simulations/adapters/json_exporter.py
+++ b/simulations/sphere_space_station_simulations/adapters/json_exporter.py
@@ -1,0 +1,38 @@
+"""Simple JSON exporter for :class:`StationModel`.
+
+The exporter serialises the complete data model into a human readable
+JSON file.  It relies on :func:`dataclasses.asdict` which correctly
+handles nested dataclasses such as decks with windows or hull
+specifications.  Tuples are converted to lists to remain valid JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from ..data_model import StationModel
+
+
+def export_json(model: StationModel, filepath: str | Path) -> Path:
+    """Export the station model to a JSON file.
+
+    Parameters
+    ----------
+    model:
+        The :class:`StationModel` instance to serialise.
+    filepath:
+        Destination path for the generated JSON document.
+
+    Returns
+    -------
+    Path
+        The path to the written file.
+    """
+
+    path = Path(filepath)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(asdict(model), handle, indent=2)
+    return path

--- a/simulations/sphere_space_station_simulations/adapters/readme.md
+++ b/simulations/sphere_space_station_simulations/adapters/readme.md
@@ -1,3 +1,3 @@
 # Adapters
 
-Prototype exporters translating internal geometry data into external formats.
+Prototype exporters translating internal geometry data into external formats such as STEP, glTF or JSON.

--- a/simulations/tests/test_adapters.py
+++ b/simulations/tests/test_adapters.py
@@ -1,10 +1,10 @@
-"""Tests for STEP and glTF prototype exporters."""
+"""Tests for prototype geometry exporters."""
 
 import os
 import sys
+import json
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
-
 
 from pathlib import Path
 
@@ -13,6 +13,9 @@ from simulations.sphere_space_station_simulations.adapters.gltf_exporter import 
 )
 from simulations.sphere_space_station_simulations.adapters.step_exporter import (
     export_step,
+)
+from simulations.sphere_space_station_simulations.adapters.json_exporter import (
+    export_json,
 )
 from simulations.sphere_space_station_simulations.data_model import (
     Deck,
@@ -31,8 +34,16 @@ def test_exporters_create_files(tmp_path: Path) -> None:
 
     step_file = export_step(model, tmp_path / "station.step")
     gltf_file = export_gltf(model, tmp_path / "station.glb")
+    json_file = export_json(model, tmp_path / "station.json")
 
     assert step_file.exists() and step_file.stat().st_size > 0
     assert gltf_file.exists()
+    assert json_file.exists()
+
     gltf = GLTF2().load(str(gltf_file))
     assert gltf.meshes and gltf.animations
+
+    with json_file.open("r", encoding="utf-8") as handle:
+        data = json.load(handle)
+    assert data["decks"][0]["windows"][0]["size_m"] == 0.2
+    assert data["hull"]["windows"][0]["position"][2] == 3.0


### PR DESCRIPTION
## Summary
- add JSON exporter for `StationModel`
- document available exporters and expose `export_json`
- extend adapter tests for JSON serialization

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f9e269430832a8f4feda0cdf7f9cd