### PR TITLE
Import hull glTF in Blender adapter and document workflow

### DIFF
--- a/documents/construction-handbook.md
+++ b/documents/construction-handbook.md
@@ -20,6 +20,9 @@ This handbook collects key decisions for modeling the Sphere Space Station and s
 
 - **Reduced dependencies**: `generate_deck_construction_csv` no longer requires Pandas and the package uses lazy imports so the Blender adapters run without extra libraries.
 - **Hull starter**: The hull simulation's `starter.py` now points to `adapter.py` by default.
+- **glTF-based hull import**: `blender_hull_simulation/adapter.py` loads the
+  geometry from a glTF file exported by `gltf_exporter.py` and assigns a simple
+  material, removing the previous CSV dependency.
 
 - **Deck rendering**: `create_ring_deck` now only removes the inner helper geometry so all decks, not just the wormhole, appear. The deck ID is now parsed correctly based on the underscore so windows are created for the first twelve decks.
 

--- a/simulations/blender_hull_simulation/adapter.py
+++ b/simulations/blender_hull_simulation/adapter.py
@@ -1,39 +1,69 @@
-"""adapter.py
-A minimal Blender script that creates a simplified hull based on the
-`deck_3d_construction_data.csv` file.
+"""Blender adapter loading a glTF hull model.
+
+The previous prototype read ``deck_3d_construction_data.csv`` and created a
+primitive sphere based on the outer deck radius.  This version assumes that the
+geometry has already been exported to a glTF file by ``gltf_exporter.py`` and
+imports it directly using Blender's Python API.  After import a simple material
+is assigned to all mesh objects so the model is immediately visible.
 
 Run this script inside Blender or from the command line with
 ``blender --python adapter.py``.
 """
 
-import csv
+from __future__ import annotations
+
 import os
-import bpy
+
+try:  # pragma: no cover - handled in tests
+    import bpy  # type: ignore
+except Exception:  # pragma: no cover - Blender not available
+    bpy = None  # type: ignore[assignment]
 
 
-def load_outer_radius(csv_path: str) -> float:
-    with open(csv_path, newline="") as f:
-        reader = csv.DictReader(f)
-        rows = list(reader)
-        if not rows:
-            raise ValueError("CSV contains no deck data")
-        outer = float(rows[-1]["outer_radius_m"])
-        return outer
+def import_gltf(filepath: str) -> None:
+    """Import a glTF file using Blender's glTF importer."""
+
+    if bpy is None:  # pragma: no cover - Blender required
+        raise ModuleNotFoundError("bpy module is required")
+    bpy.ops.import_scene.gltf(filepath=filepath)
 
 
-def create_hull(radius: float) -> None:
-    bpy.ops.object.select_all(action="SELECT")
-    bpy.ops.object.delete(use_global=False)
-    bpy.ops.mesh.primitive_uv_sphere_add(radius=radius, enter_editmode=False)
+def assign_basic_material(material_name: str = "HullMaterial") -> None:
+    """Assign a simple material to all mesh objects.
+
+    The material is created if it does not yet exist.
+    """
+
+    if bpy is None:  # pragma: no cover - Blender required
+        raise ModuleNotFoundError("bpy module is required")
+
+    mat = bpy.data.materials.get(material_name)
+    if mat is None:
+        mat = bpy.data.materials.new(name=material_name)
+        mat.diffuse_color = (0.8, 0.8, 0.8, 1.0)
+
+    for obj in bpy.data.objects:
+        if obj.type == "MESH":
+            if obj.data.materials:
+                obj.data.materials[0] = mat
+            else:
+                obj.data.materials.append(mat)
 
 
 def main() -> None:
     script_dir = os.path.dirname(__file__)
-    csv_path = os.path.join(script_dir, "deck_3d_construction_data.csv")
-    if not os.path.exists(csv_path):
-        raise FileNotFoundError(csv_path)
-    radius = load_outer_radius(csv_path)
-    create_hull(radius)
+    gltf_path = os.path.join(script_dir, "station.glb")
+    if not os.path.exists(gltf_path):
+        raise FileNotFoundError(gltf_path)
+
+    if bpy is None:  # pragma: no cover - Blender required
+        raise ModuleNotFoundError("bpy module is required")
+
+    bpy.ops.object.select_all(action="SELECT")
+    bpy.ops.object.delete(use_global=False)
+
+    import_gltf(gltf_path)
+    assign_basic_material()
 
 
 if __name__ == "__main__":

--- a/simulations/blender_hull_simulation/readme.md
+++ b/simulations/blender_hull_simulation/readme.md
@@ -1,12 +1,22 @@
 # Blender Hull Simulation
 
-This folder contains a minimal Blender Python script that generates a simple hull model for the Sphere Station. It mirrors the approach of the deck simulation but focuses solely on the outer hull.
+This folder contains a minimal Blender Python script that imports a hull model
+for the Sphere Station.  The geometry is exported beforehand by
+``gltf_exporter.py`` and stored as a glTF/GLB file which is then loaded into
+Blender.
 
-* **adapter.py** – Creates a basic hull based on `deck_3d_construction_data.csv`.
-* **starter.py** – Convenience launcher that starts Blender using the environment variable `BLENDER_PATH`.
+* **adapter.py** – Imports ``station.glb`` and assigns a grey material to all
+  meshes.
+* **starter.py** – Convenience launcher that starts Blender using the
+  environment variable ``BLENDER_PATH`` and can generate the ``station.glb``
+  file via ``--export-gltf``.
 
-`starter.py` can additionally export the station geometry using the bundled CSV:
+Example workflow:
 
 ```bash
-python starter.py --export-step hull.step --export-gltf hull.gltf --export-json hull.json
+# 1) Create glTF geometry
+python starter.py --export-gltf station.glb
+
+# 2) Open the glTF file in Blender and assign materials
+blender --python adapter.py
 ```

--- a/simulations/tests/test_blender_hull_adapter.py
+++ b/simulations/tests/test_blender_hull_adapter.py
@@ -1,0 +1,46 @@
+"""Tests for the Blender hull adapter.
+
+The adapter relies on Blender's :mod:`bpy` module which is unavailable in the
+test environment.  These tests patch in a minimal stub to ensure the script
+invokes the expected Blender API calls and assigns materials to imported
+objects.
+"""
+
+from types import SimpleNamespace
+
+from simulations.blender_hull_simulation import adapter
+
+
+def test_import_and_material_assignment(monkeypatch, tmp_path) -> None:
+    called = {}
+
+    def gltf(filepath: str) -> None:  # record the call for assertions
+        called["path"] = filepath
+
+    ops = SimpleNamespace(import_scene=SimpleNamespace(gltf=gltf))
+
+    class Materials(dict):
+        def get(self, name):
+            return super().get(name)
+
+        def new(self, name):
+            mat = SimpleNamespace(name=name, diffuse_color=None)
+            self[name] = mat
+            return mat
+
+    objects = [SimpleNamespace(type="MESH", data=SimpleNamespace(materials=[]))]
+
+    bpy_stub = SimpleNamespace(
+        ops=ops, data=SimpleNamespace(objects=objects, materials=Materials())
+    )
+
+    monkeypatch.setattr(adapter, "bpy", bpy_stub)
+
+    fake_file = tmp_path / "station.glb"
+    fake_file.touch()
+
+    adapter.import_gltf(str(fake_file))
+    adapter.assign_basic_material()
+
+    assert called["path"] == str(fake_file)
+    assert objects[0].data.materials[0].name == "HullMaterial"


### PR DESCRIPTION
## Summary
- Replace CSV-based hull creation with glTF import and basic material assignment
- Document new export/import workflow in blender_hull_simulation README
- Record design change in construction handbook and add unit test

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa0121960832ab727fbf77a3cb907