### PR TITLE
Add architecture documentation overview and link from README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,7 @@ Sphere Space Station Earth ONE and Beyond
 ## Table of Content
 - Management Summary
 - Sphere Station Documentation: Technical and Operational Overview
+- [Architecture Overview](simulations/docs/architecture/readme.md)
 
 All documents in the `documents` directory must be written in English, except for proper names.
 

--- a/simulations/docs/architecture/data-model.md
+++ b/simulations/docs/architecture/data-model.md
@@ -1,0 +1,9 @@
+# Datenmodell
+
+Dieses Dokument beschreibt die Dataclasses, die das interne Stationsmodell repräsentieren.
+
+- **Deck**: Einzelnes Deck mit Innen- und Außenradius sowie Höhe.
+- **Hull**: Umhüllt die Decks und definiert die Hüllengeometrie.
+- **StationModel**: Aggregiert alle Decks und globale Parameter.
+
+Die Implementierung befindet sich in [`simulations/sphere_space_station_simulations/data_model.py`](../../sphere_space_station_simulations/data_model.py).

--- a/simulations/docs/architecture/readme.md
+++ b/simulations/docs/architecture/readme.md
@@ -1,3 +1,11 @@
 # Architecture Documentation
 
-This folder hosts design notes for the STEP/glTF integration and CAD detail work.
+Dieses Verzeichnis bündelt Unterlagen zum Schichtenmodell des Projekts. Das Modell trennt eine **KERNEL**-Schicht für Berechnungen, **ADAPTER** zur Formatumwandlung und **GUI**-Schichten für die Visualisierung.
+
+## Übersicht
+
+| Dokument | Zweck | Speicherort |
+| --- | --- | --- |
+| [layered-architecture.md](layered-architecture.md) | Erläutert das Schichtenmodell | simulations/docs/architecture/layered-architecture.md |
+| [library-evaluation.md](library-evaluation.md) | Vergleich von STEP- und glTF-Bibliotheken | simulations/docs/architecture/library-evaluation.md |
+| [data-model.md](data-model.md) | Dokumentation des Datenmodells (`Deck`, `Hull`, `StationModel`) | simulations/docs/architecture/data-model.md |


### PR DESCRIPTION
## Summary
- Document sphere station architecture structure with links to layered design, library evaluation and data model
- Introduce data-model documentation describing Deck, Hull and StationModel
- Link project README to the architecture overview

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa9288380832ab5bf67a5559578c1