### PR TITLE
feat: auto-generate blender glb

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.1.0
+version: 1.2.0
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.2.0
+    date: 2025-08-05
+    change: "Automatic glTF generation for Blender via prepare_scene"
   - version: 1.1.0
     date: 2025-02-14
     change: "Added BaseRing DTO, material metadata and exporter tests"
@@ -41,3 +44,5 @@ No external sources used.
 - Exporters write STEP, glTF and JSON files which serve as the primary interchange formats.
 - Blender adapters import the generated glTF directly; the helper CSV `deck_3d_construction_data.csv` was removed and CSV remains only for analytical reports such as `results/deck_dimensions.csv`.
 - The data model now includes `BaseRing` elements and material/colour properties for all geometry. Exporters and tests ensure that rings and materials are preserved across STEP, glTF and JSON workflows.
+- A helper `prepare_scene` script automatically creates the required `station.glb`
+  file when Blender adapters run, reducing manual export steps.

--- a/simulations/blender_hull_simulation/adapter.py
+++ b/simulations/blender_hull_simulation/adapter.py
@@ -12,12 +12,17 @@ Run this script inside Blender or from the command line with
 
 from __future__ import annotations
 
+import argparse
 import os
 
 try:  # pragma: no cover - handled in tests
     import bpy  # type: ignore
 except Exception:  # pragma: no cover - Blender not available
     bpy = None  # type: ignore[assignment]
+try:
+    from .prepare_blender_scene import prepare_scene
+except ImportError:  # pragma: no cover - direct script execution
+    from prepare_blender_scene import prepare_scene
 
 
 def import_gltf(filepath: str) -> None:
@@ -50,9 +55,21 @@ def assign_basic_material(material_name: str = "HullMaterial") -> None:
                 obj.data.materials.append(mat)
 
 
-def main() -> None:
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--prepare", action="store_true", help="Generate scene and exit"
+    )
+    args, _ = parser.parse_known_args(argv)
+
     script_dir = os.path.dirname(__file__)
     gltf_path = os.path.join(script_dir, "station.glb")
+
+    if args.prepare or not os.path.exists(gltf_path):
+        prepare_scene(gltf_path)
+        if args.prepare:
+            return
+
     if not os.path.exists(gltf_path):
         raise FileNotFoundError(gltf_path)
 

--- a/simulations/blender_hull_simulation/prepare_blender_scene.py
+++ b/simulations/blender_hull_simulation/prepare_blender_scene.py
@@ -1,0 +1,88 @@
+"""Utility to ensure Blender hull scenes have required exports.
+
+The Blender adapter expects a ``station.glb`` file in the same directory.
+This helper generates the file on demand using the shared export
+functions.  Optional STEP and JSON files can also be created for future
+workflows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from simulations.sphere_space_station_simulations import SphereDeckCalculator
+from simulations.sphere_space_station_simulations.data_model import (
+    StationModel,
+    Deck,
+    Hull,
+)
+from simulations.sphere_space_station_simulations.adapters import (
+    export_gltf,
+    export_step,
+    export_json,
+)
+
+
+def _build_default_model() -> StationModel:
+    """Construct a default :class:`StationModel` used for Blender previews."""
+
+    calculator = SphereDeckCalculator(
+        "Deck Dimensions of a Sphere",
+        sphere_diameter=127.0,
+        hull_thickness=0.5,
+        windows_per_deck_ratio=0.20,
+        num_decks=16,
+        deck_000_outer_radius=10.5,
+        deck_height_brutto=3.5,
+        deck_ceiling_thickness=0.5,
+    )
+    calculator.calculate_dynamics_of_a_sphere(angular_velocity=0.5)
+
+    decks = [
+        Deck(
+            id=int(row[SphereDeckCalculator.DECK_ID_LABEL].split("_")[1]),
+            inner_radius_m=row[SphereDeckCalculator.INNER_RADIUS_LABEL],
+            outer_radius_m=row[SphereDeckCalculator.OUTER_RADIUS_LABEL],
+            height_m=row[SphereDeckCalculator.DECK_HEIGHT_LABEL],
+        )
+        for _, row in calculator.df_decks.iterrows()
+    ]
+
+    return StationModel(decks=decks, hull=Hull(radius_m=calculator.sphere_diameter / 2))
+
+
+def prepare_scene(
+    output_path: str | Path = "station.glb",
+    *,
+    create_step: bool = False,
+    create_json: bool = False,
+) -> Path:
+    """Ensure the required glTF file exists for Blender.
+
+    Parameters
+    ----------
+    output_path:
+        Location of the GLB/GLTF file.  If missing, it will be generated.
+    create_step, create_json:
+        When set, additional STEP and JSON files are written next to the
+        glTF.  Their filenames are derived from ``output_path``.
+    """
+
+    path = Path(output_path)
+    if path.exists():
+        return path
+
+    model = _build_default_model()
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    export_gltf(model, path)
+
+    base = path.with_suffix("")
+    if create_step:
+        export_step(model, base.with_suffix(".step"))
+    if create_json:
+        export_json(model, base.with_suffix(".json"))
+    return path
+
+
+__all__ = ["prepare_scene"]

--- a/simulations/blender_hull_simulation/readme.md
+++ b/simulations/blender_hull_simulation/readme.md
@@ -5,18 +5,20 @@ for the Sphere Station.  The geometry is exported beforehand by
 ``gltf_exporter.py`` and stored as a glTF/GLB file which is then loaded into
 Blender.
 
+* **prepare_blender_scene.py** – Generates ``station.glb`` (and optional STEP
+  or JSON files) using the shared exporters.
 * **adapter.py** – Imports ``station.glb`` and assigns a grey material to all
-  meshes.
+  meshes.  If the GLB file is missing, it is created automatically.
 * **starter.py** – Convenience launcher that starts Blender using the
-  environment variable ``BLENDER_PATH`` and can generate the ``station.glb``
-  file via ``--export-gltf``.
+  environment variable ``BLENDER_PATH`` and can still generate the
+  ``station.glb`` file via ``--export-gltf``.
 
 Example workflow:
 
 ```bash
-# 2. 1) Create glTF geometry
-python starter.py --export-gltf station.glb
-
-# 3. 2) Open the glTF file in Blender and assign materials
+# 1) Run Blender; the adapter prepares the scene if necessary
 blender --python adapter.py
+
+# Optionally generate exports without launching Blender
+blender --python adapter.py -- --prepare
 ```


### PR DESCRIPTION
## Summary
- auto-build Blender GLB exports with new `prepare_scene`
- call `prepare_scene` from hull adapter and add `--prepare` CLI switch
- document Blender scene preparation in READMEs and design decisions
- handle direct script execution by falling back to a local `prepare_scene` import

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py simulations/blender_hull_simulation/prepare_blender_scene.py simulations/blender_hull_simulation/adapter.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891d71073ac832a876da0d1cb9bed55