### PR TITLE
fix: ensure prepare_blender_scene import

### DIFF
--- a/simulations/blender_hull_simulation/adapter.py
+++ b/simulations/blender_hull_simulation/adapter.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import sys
 
 try:  # pragma: no cover - handled in tests
     import bpy  # type: ignore
@@ -22,9 +23,10 @@ except Exception:  # pragma: no cover - Blender not available
 try:
     from .prepare_blender_scene import prepare_scene
 except ImportError:  # pragma: no cover - direct script execution
+    script_path = os.path.dirname(__file__)
+    sys.path.append(script_path)
+    sys.path.append(os.path.abspath(os.path.join(script_path, "..", "..")))
     from prepare_blender_scene import prepare_scene
-
-from .prepare_blender_scene import prepare_scene
 
 
 def import_gltf(filepath: str) -> None:


### PR DESCRIPTION
## Summary
- make Blender adapter robust by appending its directory and repo root to `sys.path` when run directly
- remove duplicate import and add missing `sys` import

## Testing
- `python simulations/blender_hull_simulation/adapter.py --prepare`
- `python -m py_compile simulations/blender_hull_simulation/adapter.py`
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/blender_hull_simulation/adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_6891ddb71e08832ab7c43aa1d19c3e07