### PR TITLE
Prepare Blender scene before launch

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.2.0
+version: 1.3.0
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.0
+    date: 2025-08-05
+    change: "Moved scene preparation to starter script and simplified Blender adapter"
   - version: 1.2.0
     date: 2025-08-05
     change: "Automatic glTF generation for Blender via prepare_scene"

--- a/simulations/blender_hull_simulation/adapter.py
+++ b/simulations/blender_hull_simulation/adapter.py
@@ -12,21 +12,12 @@ Run this script inside Blender or from the command line with
 
 from __future__ import annotations
 
-import argparse
 import os
-import sys
 
 try:  # pragma: no cover - handled in tests
     import bpy  # type: ignore
 except Exception:  # pragma: no cover - Blender not available
     bpy = None  # type: ignore[assignment]
-try:
-    from .prepare_blender_scene import prepare_scene
-except ImportError:  # pragma: no cover - direct script execution
-    script_path = os.path.dirname(__file__)
-    sys.path.append(script_path)
-    sys.path.append(os.path.abspath(os.path.join(script_path, "..", "..")))
-    from prepare_blender_scene import prepare_scene
 
 
 def import_gltf(filepath: str) -> None:
@@ -60,19 +51,8 @@ def assign_basic_material(material_name: str = "HullMaterial") -> None:
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument(
-        "--prepare", action="store_true", help="Generate scene and exit"
-    )
-    args, _ = parser.parse_known_args(argv)
-
     script_dir = os.path.dirname(__file__)
     gltf_path = os.path.join(script_dir, "station.glb")
-
-    if args.prepare or not os.path.exists(gltf_path):
-        prepare_scene(gltf_path)
-        if args.prepare:
-            return
 
     if not os.path.exists(gltf_path):
         raise FileNotFoundError(gltf_path)

--- a/simulations/blender_hull_simulation/starter.py
+++ b/simulations/blender_hull_simulation/starter.py
@@ -21,6 +21,7 @@ from simulations.sphere_space_station_simulations.data_model import (
     Hull,
     StationModel,
 )
+from simulations.blender_hull_simulation.prepare_blender_scene import prepare_scene
 
 
 def main() -> None:
@@ -87,6 +88,9 @@ def main() -> None:
     if args.export_json:
         with Path(args.export_json).open("w", encoding="utf-8") as fh:
             json.dump(asdict(model), fh, indent=2)
+
+    script_dir = os.path.dirname(__file__)
+    prepare_scene(os.path.join(script_dir, "station.glb"))
 
     blender = args.blender
     if not blender:


### PR DESCRIPTION
## Summary
- generate `station.glb` in the starter script before calling Blender
- remove dynamic scene preparation from `adapter.py`
- document the change in the simulation design decisions

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891e4657a24832a9f4d9c45bc6001a3