### PR TITLE
Fix glTF root node indexing

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.0
+version: 1.3.1
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.1
+    date: 2025-08-05
+    change: "Corrected root node placement in glTF exporter to avoid recursion"
   - version: 1.3.0
     date: 2025-08-05
     change: "Moved scene preparation to starter script and simplified Blender adapter"

--- a/simulations/sphere_space_station_simulations/adapters/gltf_exporter.py
+++ b/simulations/sphere_space_station_simulations/adapters/gltf_exporter.py
@@ -366,8 +366,8 @@ def export_gltf(model: StationModel, filepath: str | Path) -> Path:
         )
         child_nodes.append(len(nodes) - 1)
 
-    root = Node(children=child_nodes)
-    nodes.insert(0, root)
+    root_idx = len(nodes)
+    nodes.append(Node(children=child_nodes))
 
     # Animation data (rotation around Z axis)
     time_data = np.array([0.0, 1.0], dtype=np.float32)
@@ -405,12 +405,12 @@ def export_gltf(model: StationModel, filepath: str | Path) -> Path:
 
     sampler = AnimationSampler(input=len(accessors) - 2, output=len(accessors) - 1)
     channel = AnimationChannel(
-        sampler=0, target=AnimationChannelTarget(node=0, path="rotation")
+        sampler=0, target=AnimationChannelTarget(node=root_idx, path="rotation")
     )
     animations = [Animation(samplers=[sampler], channels=[channel])]
 
     buffer = Buffer(byteLength=len(binary))
-    scene = Scene(nodes=[0])
+    scene = Scene(nodes=[root_idx])
     gltf = GLTF2(
         scenes=[scene],
         nodes=nodes,


### PR DESCRIPTION
## Summary
- prevent glTF root from shifting child indices by appending it at the end
- note the glTF exporter fix in the simulation design documentation

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689209624fb4832a8b547929aeefb8b5