### PR TITLE
Automate Blender deck simulation exports

### DIFF
--- a/simulations/blender_deck_simulator/prepare_blender_scene.py
+++ b/simulations/blender_deck_simulator/prepare_blender_scene.py
@@ -1,0 +1,88 @@
+"""Utility to ensure Blender deck scenes have required exports.
+
+The Blender adapter expects a ``station.glb`` file in the same directory.
+This helper generates the file on demand using the shared export
+functions.  Optional STEP and JSON files can also be created for future
+workflows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from simulations.sphere_space_station_simulations import SphereDeckCalculator
+from simulations.sphere_space_station_simulations.data_model import (
+    StationModel,
+    Deck,
+    Hull,
+)
+from simulations.sphere_space_station_simulations.adapters import (
+    export_gltf,
+    export_step,
+    export_json,
+)
+
+
+def _build_default_model() -> StationModel:
+    """Construct a default :class:`StationModel` used for Blender previews."""
+
+    calculator = SphereDeckCalculator(
+        "Deck Dimensions of a Sphere",
+        sphere_diameter=127.0,
+        hull_thickness=0.5,
+        windows_per_deck_ratio=0.20,
+        num_decks=16,
+        deck_000_outer_radius=10.5,
+        deck_height_brutto=3.5,
+        deck_ceiling_thickness=0.5,
+    )
+    calculator.calculate_dynamics_of_a_sphere(angular_velocity=0.5)
+
+    decks = [
+        Deck(
+            id=int(row[SphereDeckCalculator.DECK_ID_LABEL].split("_")[1]),
+            inner_radius_m=row[SphereDeckCalculator.INNER_RADIUS_LABEL],
+            outer_radius_m=row[SphereDeckCalculator.OUTER_RADIUS_LABEL],
+            height_m=row[SphereDeckCalculator.DECK_HEIGHT_LABEL],
+        )
+        for _, row in calculator.df_decks.iterrows()
+    ]
+
+    return StationModel(decks=decks, hull=Hull(radius_m=calculator.sphere_diameter / 2))
+
+
+def prepare_scene(
+    output_path: str | Path = "station.glb",
+    *,
+    create_step: bool = False,
+    create_json: bool = False,
+) -> Path:
+    """Ensure the required glTF file exists for Blender.
+
+    Parameters
+    ----------
+    output_path:
+        Location of the GLB/GLTF file.  If missing, it will be generated.
+    create_step, create_json:
+        When set, additional STEP and JSON files are written next to the
+        glTF.  Their filenames are derived from ``output_path``.
+    """
+
+    path = Path(output_path)
+    if path.exists():
+        return path
+
+    model = _build_default_model()
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    export_gltf(model, path)
+
+    base = path.with_suffix("")
+    if create_step:
+        export_step(model, base.with_suffix(".step"))
+    if create_json:
+        export_json(model, base.with_suffix(".json"))
+    return path
+
+
+__all__ = ["prepare_scene"]

--- a/simulations/blender_deck_simulator/readme.md
+++ b/simulations/blender_deck_simulator/readme.md
@@ -1,18 +1,20 @@
 # 1. Blender Deck Simulator
 
 Dieses Verzeichnis enthält die Proof-of-Concept-Dateien für Blender, mit denen
-Decks der Sphere Station visualisiert werden. Die Geometrie wird inzwischen
-über eine glTF-Datei bereitgestellt; die früher genutzten CSV-Hilfsdateien
-entfallen.
+Decks der Sphere Station visualisiert werden. Die Geometrie wird über eine
+GLB-Datei bereitgestellt und bei Bedarf automatisch erzeugt.
 
-* **adapter.py** – importiert `station.glb` und weist einfachen Materialien
-  zu.
+* **prepare_blender_scene.py** – generiert `station.glb` (optional STEP oder
+  JSON) mittels der gemeinsamen Exportfunktionen.
+* **adapter.py** – importiert `station.glb` und weist einfachen Materialien zu.
 * **starter.py** – Komfortskript zum Starten von Blender über die
-  Umgebungsvariable `BLENDER_PATH`.
+  Umgebungsvariable `BLENDER_PATH`; ruft `prepare_scene` auf, um fehlende
+  Exportdateien zu erzeugen.
 
 ## 1.1 Ausführen in Blender
 
-1. Exportiere `station.glb` mit dem glTF-Exporter.
+1. Falls nicht vorhanden, `prepare_blender_scene.py` ausführen, um `station.glb`
+   zu erzeugen.
 2. Starte Blender (≥ 2.9) und wechsle in den Arbeitsbereich **Scripting**.
 3. Lade `adapter.py` und führe das Skript aus (`Alt+P`) oder rufe
    `blender --python adapter.py` auf.
@@ -26,4 +28,6 @@ starte anschließend:
 python starter.py --background
 ```
 
-Weitere Argumente werden direkt an Blender weitergereicht.
+Weitere Argumente werden direkt an Blender weitergereicht. Über die Parameter
+`--export-step`, `--export-gltf` und `--export-json` lassen sich zusätzliche
+Dateien erzeugen.

--- a/simulations/blender_deck_simulator/starter.py
+++ b/simulations/blender_deck_simulator/starter.py
@@ -1,12 +1,32 @@
 import argparse
+import json
 import os
 import subprocess
 import sys
+from dataclasses import asdict
+from pathlib import Path
+
+# Allow execution without installing the package by adding the repository root
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from simulations.sphere_space_station_simulations import SphereDeckCalculator
+from simulations.sphere_space_station_simulations.adapters.gltf_exporter import (
+    export_gltf,
+)
+from simulations.sphere_space_station_simulations.adapters.step_exporter import (
+    export_step,
+)
+from simulations.sphere_space_station_simulations.data_model import (
+    Deck,
+    Hull,
+    StationModel,
+)
+from simulations.blender_deck_simulator.prepare_blender_scene import prepare_scene
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Launch Blender with the deck simulation script"
+        description="Launch Blender with the deck simulation script",
     )
     parser.add_argument(
         "--blender",
@@ -19,8 +39,19 @@ def main() -> None:
         help="Blender Python file to execute",
     )
     parser.add_argument(
-        "--background", action="store_true", help="Run Blender in background mode"
+        "--background",
+        action="store_true",
+        help="Run Blender in background mode",
     )
+    parser.add_argument(
+        "--export-step",
+        help="Write a STEP file with the station geometry",
+    )
+    parser.add_argument(
+        "--export-gltf",
+        help="Write a glTF file with the station geometry",
+    )
+    parser.add_argument("--export-json", help="Write the station data model as JSON")
     parser.add_argument(
         "extra",
         nargs=argparse.REMAINDER,
@@ -28,6 +59,43 @@ def main() -> None:
     )
 
     args = parser.parse_args()
+
+    calculator = SphereDeckCalculator(
+        "Deck Dimensions of a Sphere",
+        sphere_diameter=127.0,
+        hull_thickness=0.5,
+        windows_per_deck_ratio=0.20,
+        num_decks=16,
+        deck_000_outer_radius=10.5,
+        deck_height_brutto=3.5,
+        deck_ceiling_thickness=0.5,
+    )
+    calculator.calculate_dynamics_of_a_sphere(angular_velocity=0.5)
+
+    model = StationModel(
+        decks=[
+            Deck(
+                id=int(row[SphereDeckCalculator.DECK_ID_LABEL].split("_")[1]),
+                inner_radius_m=row[SphereDeckCalculator.INNER_RADIUS_LABEL],
+                outer_radius_m=row[SphereDeckCalculator.OUTER_RADIUS_LABEL],
+                height_m=row[SphereDeckCalculator.DECK_HEIGHT_LABEL],
+            )
+            for _, row in calculator.df_decks.iterrows()
+        ],
+        hull=Hull(radius_m=calculator.sphere_diameter / 2),
+    )
+
+    if args.export_step:
+        export_step(model, Path(args.export_step))
+    if args.export_gltf:
+        export_gltf(model, Path(args.export_gltf))
+    if args.export_json:
+        with Path(args.export_json).open("w", encoding="utf-8") as fh:
+            json.dump(asdict(model), fh, indent=2)
+
+    script_dir = os.path.dirname(__file__)
+    prepare_scene(os.path.join(script_dir, "station.glb"))
+
     blender = args.blender
     if not blender:
         print("BLENDER_PATH not set and --blender not provided", file=sys.stderr)


### PR DESCRIPTION
## Summary
- add prepare_scene helper to auto-generate station.glb for deck simulation
- extend deck starter script with optional STEP/JSON exports and automatic scene preparation
- document new workflow for deck simulator

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest simulations/tests`
- `pytest` *(fails: IndexError in `test_animations`)*

------
https://chatgpt.com/codex/tasks/task_e_6892264908d0832a8164360035f8d550