### PR TITLE
Add concise logging to simulations

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.2
+version: 1.3.3
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.3
+    date: 2025-08-07
+    change: "Shortened logger names for Blender scene prep and glTF exporter"
   - version: 1.3.2
     date: 2025-08-06
     change: "Added logging to simulation modules for better diagnostics"

--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.1
+version: 1.3.2
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.2
+    date: 2025-08-06
+    change: "Added logging to simulation modules for better diagnostics"
   - version: 1.3.1
     date: 2025-08-05
     change: "Corrected root node placement in glTF exporter to avoid recursion"

--- a/simulations/blender_deck_simulator/prepare_blender_scene.py
+++ b/simulations/blender_deck_simulator/prepare_blender_scene.py
@@ -22,8 +22,8 @@ from simulations.sphere_space_station_simulations.adapters import (
     export_json,
 )
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+
+log = logging.getLogger("prep")
 
 
 def _build_default_model() -> StationModel:
@@ -77,21 +77,21 @@ def prepare_scene(
     if not force_new:
         # If the file already exists and we are not forcing a new one, return the existing path
         if path.exists():
-            logger.info(f"Using existing glTF file at {path}")
+            log.info("Using existing glTF file at %s", path)
             return path
     else:
         # If we are forcing a new one, delete the existing file if it exists
         if path.exists():
             path.unlink()
-            logger.info(f"Deleted existing glTF file at {path}")
+            log.info("Deleted existing glTF file at %s", path)
 
     # Ensure the parent directory exists
     if not path.parent.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Created directory {path.parent}")
+        log.info("Created directory %s", path.parent)
 
     # If the file does not exist, we need to create it
-    logger.info(f"Preparing scene at {path}")
+    log.info("Preparing scene at %s", path)
     # Build the default model
     model = _build_default_model()
 

--- a/simulations/blender_hull_simulation/prepare_blender_scene.py
+++ b/simulations/blender_hull_simulation/prepare_blender_scene.py
@@ -22,8 +22,8 @@ from simulations.sphere_space_station_simulations.adapters import (
     export_json,
 )
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+
+log = logging.getLogger("prep")
 
 
 def _build_default_model() -> StationModel:
@@ -76,21 +76,21 @@ def prepare_scene(
     if not force_new:
         # If the file already exists and we are not forcing a new one, return the existing path
         if path.exists():
-            logger.info(f"Using existing glTF file at {path}")
+            log.info("Using existing glTF file at %s", path)
             return path
     else:
         # If we are forcing a new one, delete the existing file if it exists
         if path.exists():
             path.unlink()
-            logger.info(f"Deleted existing glTF file at {path}")
+            log.info("Deleted existing glTF file at %s", path)
 
     # Ensure the parent directory exists
     if not path.parent.exists():
         path.parent.mkdir(parents=True, exist_ok=True)
-        logger.info(f"Created directory {path.parent}")
+        log.info("Created directory %s", path.parent)
 
     # If the file does not exist, we need to create it
-    logger.info(f"Preparing scene at {path}")
+    log.info("Preparing scene at %s", path)
 
     # Build the default model
     model = _build_default_model()

--- a/simulations/sphere_space_station_simulations/adapters/gltf_exporter.py
+++ b/simulations/sphere_space_station_simulations/adapters/gltf_exporter.py
@@ -12,8 +12,8 @@ import logging
 from pathlib import Path
 from typing import List, Tuple
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger(__name__)
+
+log = logging.getLogger("gltf")
 
 # ``cadquery`` is an optional dependency used for generating the geometry of the
 # space station.  The test environment does not provide it, so the module falls
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 try:  # pragma: no cover - exercised indirectly in tests
     import cadquery as cq  # type: ignore
 except Exception:  # pragma: no cover - cadquery is optional
-    logger.info("---- CadQuery not available, using placeholder meshes. ----")
+    log.info("---- CadQuery not available, using placeholder meshes. ----")
     # Set `cq` to None so that the rest of the code can check for its availability
     cq = None  # type: ignore[assignment]
 import numpy as np
@@ -277,7 +277,7 @@ def export_gltf(model: StationModel, filepath: str | Path) -> Path:
     path = Path(filepath)
     path.parent.mkdir(parents=True, exist_ok=True)
 
-    logger.info(f"Exporting glTF to {path}")
+    log.info("Exporting glTF to %s", path)
     binary = bytearray()
     buffer_views: List[BufferView] = []
     accessors: List[Accessor] = []

--- a/simulations/sphere_space_station_simulations/geometry/deck.py
+++ b/simulations/sphere_space_station_simulations/geometry/deck.py
@@ -1,17 +1,21 @@
-import pandas as pd
-import numpy as np
+import logging
 from pathlib import Path
+from typing import Union, List
 
-from mpl_toolkits.mplot3d import Axes3D
-from matplotlib.animation import FuncAnimation
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.animation import FuncAnimation
+from mpl_toolkits.mplot3d import Axes3D
 from tqdm import tqdm
-from typing import Union, List
 
 from .. import animation as animation_mod
 from .. import reporting as reporting_mod
 from .hull import calculate_hull_geometry
+
+
+log = logging.getLogger("calc")
 
 RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
 DATA_DIR = RESULTS_DIR / "data"
@@ -83,6 +87,7 @@ class SphereDeckCalculator:
         self.deck_000_outer_radius = deck_000_outer_radius
         self.deck_height_brutto = deck_height_brutto
         self.deck_ceiling_thickness = deck_ceiling_thickness
+        log.info("Deck calculator initialized: %s", title)
         self.df_decks = self._calculate_cylindric_decks_of_a_sphere()
         self.hull_geometry = calculate_hull_geometry(
             self.inner_sphere_diameter,
@@ -232,6 +237,7 @@ class SphereDeckCalculator:
         return df_decks
 
     def calculate_dynamics_of_a_sphere(self, angular_velocity: float):
+        log.info("Calculating dynamics with angular velocity %.2f", angular_velocity)
         self.df_decks[self.ROTATION_VELOCITY_LABEL] = (
             self.df_decks[self.OUTER_RADIUS_NETTO_LABEL] * angular_velocity
         )
@@ -239,7 +245,6 @@ class SphereDeckCalculator:
             self.df_decks[self.ROTATION_VELOCITY_LABEL] ** 2
             / self.df_decks[self.OUTER_RADIUS_NETTO_LABEL]
         )
-
         return self.df_decks
 
     def calculate_total_volume(self):

--- a/simulations/sphere_space_station_simulations/simulation.py
+++ b/simulations/sphere_space_station_simulations/simulation.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,9 @@ from simulations.sphere_space_station_simulations.data_model import (
 )
 
 
+log = logging.getLogger("sim")
+
+
 class StationSimulation:
     """High level simulation integrating deck and hull models."""
 
@@ -34,7 +38,7 @@ class StationSimulation:
         self.enable_life_support = enable_life_support
         self.enable_emergency_drills = enable_emergency_drills
 
-        # Load deck and hull models using the existing calculator
+        log.info("Loading station geometry")
         self.calculator = SphereDeckCalculator(
             "Deck Dimensions of a Sphere",
             sphere_diameter=127.0,
@@ -51,18 +55,19 @@ class StationSimulation:
         self.hull = self.calculator.hull_geometry
 
     def simulate_docking(self) -> None:
-        print("[Docking] Simulating spacecraft docking operations...")
+        log.info("Simulating spacecraft docking operations")
 
     def run_mission_control(self) -> None:
-        print("[Mission] Executing mission control scenario...")
+        log.info("Executing mission control scenario")
 
     def run_life_support(self) -> None:
-        print("[Life Support] Running life-support simulation...")
+        log.info("Running life-support simulation")
 
     def run_emergency_drills(self) -> None:
-        print("[Emergency] Performing emergency drill sequence...")
+        log.info("Performing emergency drill sequence")
 
     def run(self) -> None:
+        log.info("Running station simulation")
         if self.enable_docking:
             self.simulate_docking()
         if self.enable_mission_control:
@@ -71,6 +76,7 @@ class StationSimulation:
             self.run_life_support()
         if self.enable_emergency_drills:
             self.run_emergency_drills()
+        log.info("Station simulation finished")
 
     def to_station_model(self) -> StationModel:
         return StationModel(
@@ -124,6 +130,7 @@ def parse_args(args: Any | None = None) -> argparse.Namespace:
 
 
 def main(args: Any | None = None) -> None:
+    logging.basicConfig(level=logging.INFO)
     cli_args = parse_args(args)
     sim = StationSimulation(
         enable_docking=cli_args.docking,


### PR DESCRIPTION
## Summary
- add `sim` logger to StationSimulation and log key phases
- add `calc` logger to SphereDeckCalculator for initialization and dynamics
- note logging enhancement in software design decisions

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/simulation.py simulations/sphere_space_station_simulations/geometry/deck.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/simulation.py simulations/sphere_space_station_simulations/geometry/deck.py`
- `pytest simulations/tests/test_station_simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_689248b131d4832a9eb5d926cc7a59cd