### PR TITLE
Fix window material handling in STEP exporter

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/02-engineering/02-concepts/construction-handbook.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/02-engineering/02-concepts/construction-handbook.md
@@ -1,9 +1,12 @@
 ---
 title: "Construction Handbook"
-version: 1.1.0
+version: 1.1.1
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.1.1
+    date: 2025-08-10
+    change: "Corrected window material handling in STEP exporter"
   - version: 1.1.0
     date: 2025-08-08
     change: "Integrated deck supports and docking port planning into simulation"
@@ -38,6 +41,7 @@ This handbook collects key decisions for modeling the Sphere Space Station and s
 - **CLI exporter**: Starter scripts now support `--export-step`, `--export-gltf`, and `--export-json` to output geometry files; CSV remains as reporting output.
 - **Detailed data model**: `Deck` and `Hull` include net radii, cylinder lengths, base areas, and volumes, and support nested window specifications (position, size, count).
 - **CAD and glTF exporters**: STEP files now contain B-rep solids with material placeholders (steel/glass); the glTF export generates meshes with PBR materials and a simple rotation animation.
+- **Window materials**: STEP exporter uses material settings from `Window` instances instead of CadQuery solids.
 - **STEP archiving**: The generated `station.step` is stored as the Base64 file `station.step.base64` to avoid binary diffs.
 
 Further adjustments and releases will be added to this document.

--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.5
+version: 1.3.6
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.6
+    date: 2025-08-10
+    change: "Fixed STEP exporter window material reference"
   - version: 1.3.5
     date: 2025-08-09
     change: "Added Sprint-L3 engineering guidelines"
@@ -64,3 +67,4 @@ No external sources used.
 - The data model now includes `BaseRing` elements and material/colour properties for all geometry. Exporters and tests ensure that rings and materials are preserved across STEP, glTF and JSON workflows.
 - A helper `prepare_scene` script automatically creates the required `station.glb`
   file when Blender adapters run, reducing manual export steps.
+- The STEP exporter now reads window materials from the underlying `Window` instances.

--- a/simulations/sphere_space_station_simulations/adapters/step_exporter.py
+++ b/simulations/sphere_space_station_simulations/adapters/step_exporter.py
@@ -93,11 +93,14 @@ if cq is not None:  # pragma: no cover - exercised when cadquery is installed
                 },
             )
             for i, win in enumerate(windows):
+                window = deck.windows[i]
                 assembly.add(
                     win,
                     name=f"deck_{deck.id}_window_{i}",
                     metadata={
-                        "material": (win.material.name if win.material else "Glas")
+                        "material": (
+                            window.material.name if window.material else "Glas"
+                        )
                     },
                 )
 
@@ -113,8 +116,15 @@ if cq is not None:  # pragma: no cover - exercised when cadquery is installed
                 },
             )
             for i, win in enumerate(windows):
+                window = model.hull.windows[i]
                 assembly.add(
-                    win, name=f"hull_window_{i}", metadata={"material": "Glas"}
+                    win,
+                    name=f"hull_window_{i}",
+                    metadata={
+                        "material": (
+                            window.material.name if window.material else "Glas"
+                        )
+                    },
                 )
 
         if model.wormhole:

--- a/simulations/tests/test_exporters.py
+++ b/simulations/tests/test_exporters.py
@@ -25,7 +25,9 @@ from simulations.sphere_space_station_simulations.data_model import (
     BaseRing,
     Deck,
     Hull,
+    Material,
     StationModel,
+    Window,
     Wormhole,
 )
 from simulations.blender_hull_simulation import adapter
@@ -123,3 +125,12 @@ def test_step_placeholder_contains_ring_count(tmp_path: Path) -> None:
     with step_path.open("r", encoding="utf-8") as handle:
         content = handle.read()
     assert f"base_rings={len(model.base_rings)}" in content
+
+
+def test_step_exporter_handles_window_material(tmp_path: Path) -> None:
+    model = _make_model()
+    model.decks[0].windows = [
+        Window(position=(0.0, 0.0, 0.0), size_m=0.5, material=Material("Glas"))
+    ]
+    step_path = export_step(model, tmp_path / "station.step")
+    assert step_path.exists()


### PR DESCRIPTION
## Summary
- ensure STEP exporter reads materials from Window instances
- add regression test for window material handling
- document fix in construction handbook and software design decisions

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/adapters/step_exporter.py simulations/tests/test_exporters.py`
- `pytest simulations/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6893aba5a284832ab393e82957dc48c7