### PR TITLE
docs: add sprint L3-4 acceptance report

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/sprint-l3/acceptance-report-sprint-l3-4.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/sprint-l3/acceptance-report-sprint-l3-4.md
@@ -1,0 +1,31 @@
+---
+title: "Acceptance Report Sprint L3-4"
+version: 1.0.0
+owner: "Robert Alexander Massinger"
+license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
+---
+
+# Acceptance Report Sprint L3-4
+
+Sprint 4 of the plan "STEP/glTF Integration & CAD Detailing" (10 Nov 2025 – 21 Nov 2025) aimed to integrate the new exporters, document the workflow and introduce continuous quality assurance. The repository's current state was evaluated against the sprint goals.
+
+## Completed Points
+
+| Topic | Implemented Status | Reference |
+| --- | --- | --- |
+| Basic CI pipeline | A GitHub Actions workflow runs linting and the unit test suite for Python code. | `.github/workflows/python-package.yml` |
+| Legacy CSV cleanup | Geometry transport via CSV has been removed; remaining CSV files are limited to analytical reports. | `simulations/docs/architecture/readme.md` |
+
+## Still Open / Deltas
+
+| Planned Task | Current State | How it needs to be implemented |
+| --- | --- | --- |
+| **Integration tests** | No end-to-end test (`tests/test_integration.py`) exists. | Add a test that generates geometry, exports STEP/glTF and verifies Blender or a viewer can import the files. |
+| **Documentation update** | Main README and architecture docs remain monolingual and lack migration notes. | Provide bilingual documentation with examples of new CLI options and the layer model. |
+| **Refactoring & cleanup** | Historical references to `deck_3d_construction_data.csv` remain (e.g., in `simulations/deck_calculator/description.md`). | Remove outdated CSV mentions and ensure consistent naming/PEP8 across modules. |
+| **Continuous Integration** | No dedicated workflow file (`ci.yml`) for STEP/glTF exports or Blender scripts. | Create a workflow that runs exporters, tests Blender imports and uploads STEP/glTF artifacts. |
+| **Stakeholder review & backlog** | No `project/backlog.md` capturing feedback exists. | Create the backlog file summarizing stakeholder feedback and follow-up items. |
+
+## Conclusion
+
+From the product owner's perspective, Sprint 4 has not been completed. While a basic CI pipeline and the removal of CSV-based geometry transport are in place, key deliverables—integration tests, comprehensive documentation, a dedicated CI workflow and a stakeholder backlog—are still missing. These items should be addressed before Sprint L3 can be considered finished.


### PR DESCRIPTION
## Summary
- add acceptance report for Sprint L3-4 covering integration, documentation, and QA goals

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894b6c5dd10832aae8b707c0fd4b992