### PR TITLE
Add integration test and export CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: STEP and glTF CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  export-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Generate geometry files
+        run: |
+          python -m simulations.sphere_space_station_simulations.simulation \
+            --export-step station.step \
+            --export-gltf station.glb \
+            --export-json station.json
+      - name: Verify glTF
+        run: |
+          python - <<'PY'
+          from pygltflib import GLTF2
+          GLTF2().load('station.glb')
+          PY
+      - name: Run tests
+        run: pytest -q
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: geometry
+          path: |
+            station.step
+            station.glb
+            station.json

--- a/project/backlog.md
+++ b/project/backlog.md
@@ -1,0 +1,10 @@
+# Backlog
+
+This backlog collects stakeholder feedback and follow-up items after Sprint L3-4.
+
+## Items
+- Add end-to-end integration tests for STEP and glTF exports.
+- Extend bilingual documentation with CLI examples and layer model description.
+- Clean up historical CSV references and apply PEP8 naming.
+- Provide dedicated CI workflow for exporters and Blender validation.
+- Review additional stakeholder suggestions in future sprints.

--- a/readme.md
+++ b/readme.md
@@ -8,6 +8,30 @@ Sphere Space Station Earth ONE and Beyond
 - Sphere Station Documentation: Technical and Operational Overview
 - [Architecture Overview](simulations/docs/architecture/readme.md)
 
+### 1.1.1 CLI Export Options / CLI-Exportoptionen
+
+Use the simulation starter to create geometry files:
+
+```bash
+python -m simulations.sphere_space_station_simulations.simulation \
+    --export-step station.step \
+    --export-gltf station.glb \
+    --export-json station.json
+```
+
+Mit dem obigen Befehl lassen sich STEP-, glTF- und JSON-Dateien erzeugen. Der
+frühere CSV-Transport für Geometriedaten wurde entfernt.
+
+### 1.1.2 Layer Model / Schichtenmodell
+
+The project follows a layered architecture separating **KERNEL**,
+**ADAPTER** and **GUI** components. Details are documented in
+`simulations/docs/architecture`.
+
+Das Projekt verwendet ein Schichtenmodell mit **KERNEL**-, **ADAPTER**- und
+**GUI**-Ebenen. Weitere Informationen stehen in
+`simulations/docs/architecture`.
+
 All documents in the `documents` directory must be written in English, except for proper names.
 
 ---

--- a/simulations/blender_hull_simulation/adapter.py
+++ b/simulations/blender_hull_simulation/adapter.py
@@ -1,10 +1,9 @@
 """Blender adapter loading a glTF hull model.
 
-The previous prototype read ``deck_3d_construction_data.csv`` and created a
-primitive sphere based on the outer deck radius.  This version assumes that the
-geometry has already been exported to a glTF file by ``gltf_exporter.py`` and
-imports it directly using Blender's Python API.  After import a simple material
-is assigned to all mesh objects so the model is immediately visible.
+This version assumes that the geometry has already been exported to a glTF file
+by ``gltf_exporter.py`` and imports it directly using Blender's Python API.
+After import a simple material is assigned to all mesh objects so the model is
+immediately visible.
 
 Run this script inside Blender or from the command line with
 ``blender --python adapter.py``.

--- a/simulations/deck_calculator/description.md
+++ b/simulations/deck_calculator/description.md
@@ -1,6 +1,6 @@
 # 1. Beschreibung der Deckdaten
 
-Diese Datei erläutert die Struktur der CSV `deck_3d_construction_data.csv`. Die Werte stammen aus den Berechnungen des Skriptes `generate_3d_construction_csv.py` und dienen der Erstellung der 3D-Segmente in Blender.
+Diese Datei erläutert die berechneten Deckparameter der Station. Die frühere CSV `deck_3d_construction_data.csv` wurde entfernt; Geometriedaten werden jetzt direkt über die CLI‑Optionen `--export-step` und `--export-gltf` erzeugt und anschließend in Blender importiert.
 
 ## 1.1 Grundbeschreibung was ein DECK ist
 Der Raum zwischen einer koaxialer Sphere Röhre n (mit Durchmesser d1) und der nächsten koaxialen Sphere Röhre n+1 (mit Durchmesser d2, wobei d2 > d1).

--- a/simulations/docs/architecture/readme.md
+++ b/simulations/docs/architecture/readme.md
@@ -1,18 +1,32 @@
-# 1. Architecture Documentation
+# 1. Architecture Documentation / Architekturdokumentation
+
+This directory bundles notes about the project's layered model. The model
+separates a **KERNEL** layer for calculations, **ADAPTERS** for format
+conversion and **GUI** layers for visualisation.
 
 Dieses Verzeichnis bündelt Unterlagen zum Schichtenmodell des Projekts. Das
-Modell trennt eine **KERNEL**-Schicht für Berechnungen, **ADAPTER** zur
-Formatumwandlung und **GUI**-Schichten für die Visualisierung.
+Modell trennt eine **KERNEL**‑Schicht für Berechnungen, **ADAPTER** zur
+Formatumwandlung und **GUI**‑Schichten für die Visualisierung.
 
-## 1.1 Übersicht
+## 1.1 Overview / Überblick
 
-| Dokument | Zweck | Speicherort |
+| Document | Zweck | Speicherort |
 | --- | --- | --- |
-| [layered-architecture.md](layered-architecture.md) | Erläutert das Schichtenmodell | simulations/docs/architecture/layered-architecture.md |
-| [library-evaluation.md](library-evaluation.md) | Vergleich von STEP- und glTF-Bibliotheken | simulations/docs/architecture/library-evaluation.md |
-| [data-model.md](data-model.md) | Dokumentation des Datenmodells (`Deck`, `Hull`, `Wormhole`, `StationModel`) | simulations/docs/architecture/data-model.md |
+| [layered-architecture.md](layered-architecture.md) | Layer model explanation / Erläutert das Schichtenmodell | simulations/docs/architecture/layered-architecture.md |
+| [library-evaluation.md](library-evaluation.md) | STEP vs. glTF libraries / Vergleich von STEP- und glTF-Bibliotheken | simulations/docs/architecture/library-evaluation.md |
+| [data-model.md](data-model.md) | Data model (`Deck`, `Hull`, `Wormhole`, `StationModel`) / Dokumentation des Datenmodells | simulations/docs/architecture/data-model.md |
 
-## 1.2 Exporter und Datenflüsse
+## 1.2 Exporters and Data Flow / Exporter und Datenflüsse
+
+The KERNEL layer provides structured geometry which adapters convert into
+various formats:
+
+- [`gltf_exporter.py`](../../sphere_space_station_simulations/adapters/gltf_exporter.py)
+  writes `station.glb` for Blender imports.
+- [`step_exporter.py`](../../sphere_space_station_simulations/adapters/step_exporter.py)
+  writes `station.step` for CAD workflows.
+- [`json_exporter.py`](../../sphere_space_station_simulations/adapters/json_exporter.py)
+  serialises the full data model.
 
 Die KERNEL-Schicht liefert strukturierte Geometrie, die über Adapter in
 verschiedene Formate überführt wird:
@@ -24,6 +38,18 @@ verschiedene Formate überführt wird:
 - [`json_exporter.py`](../../sphere_space_station_simulations/adapters/json_exporter.py)
   serialisiert das komplette Datenmodell.
 
+Blender adapters import only glTF files. The legacy CSV transport has been
+removed; CSV remains only for analytical reports like
+`results/deck_dimensions.csv`.
+
 Blender‑Adapter laden ausschließlich glTF-Dateien. Der frühere
 CSV-Transport (`deck_3d_construction_data.csv`) wurde entfernt und CSV bleibt
 nur für tabellarische Reports wie `results/deck_dimensions.csv` erhalten.
+
+## 1.3 Migration Notes / Migrationshinweise
+
+Use the CLI options `--export-step` and `--export-gltf` to generate geometry
+files for the adapters.
+
+Verwenden Sie die CLI‑Optionen `--export-step` und `--export-gltf`, um
+Geometriedateien für die Adapter zu erzeugen.

--- a/simulations/tests/test_integration.py
+++ b/simulations/tests/test_integration.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+from pygltflib import GLTF2
+
+from simulations.sphere_space_station_simulations.simulation import StationSimulation
+from simulations.sphere_space_station_simulations.adapters import (
+    export_gltf,
+    export_step,
+)
+
+
+def test_exported_files_can_be_imported(tmp_path: Path) -> None:
+    sim = StationSimulation()
+    model = sim.to_station_model()
+
+    step_path = export_step(model, tmp_path / "station.step")
+    gltf_path = export_gltf(model, tmp_path / "station.glb")
+
+    assert step_path.exists() and step_path.stat().st_size > 0
+    assert gltf_path.exists() and gltf_path.stat().st_size > 0
+
+    # Verify that a viewer can load the glTF file
+    gltf = GLTF2().load(str(gltf_path))
+    assert gltf.meshes
+
+    # Verify STEP placeholder header
+    with step_path.open("r", encoding="utf-8") as handle:
+        first_line = handle.readline().strip()
+    assert first_line.startswith("STEP")


### PR DESCRIPTION
## Summary
- add end-to-end test exporting STEP/glTF and verifying import
- document CLI options and layered architecture in English and German
- remove outdated CSV references and add dedicated CI workflow with artifacts
- create backlog for stakeholder feedback

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894c4617f64832a92ff5a2c4a7e9de3