### PR TITLE
feat: add scene model configuration

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/questions_to_clarify.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/questions_to_clarify.md
@@ -1,0 +1,7 @@
+# Questions to Clarify
+
+1. Should `SceneConfiguration` default all modules to `false`, or are some modules considered core and enabled by default?
+2. Will module-specific parameters (e.g. number of elevators or reactor output) be stored in the same configuration file or in separate module configs?
+3. Where should `full_scene.toml` reside in the repository, and are multiple example configs (minimal/full) expected?
+4. Are there additional optional modules beyond the six listed in Sprint L4 that we should account for in an extensible schema?
+5. Should the `SceneModel` expose modules via a collection object instead of boolean flags to better support future module metadata?

--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.8
+version: 1.3.9
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.9
+    date: 2025-08-13
+    change: "Introduced SceneModel and configuration flags for optional modules"
   - version: 1.3.8
     date: 2025-08-12
     change: "Introduced Support and DockingPort DTOs with exporter and CLI integration"
@@ -75,3 +78,11 @@ No external sources used.
   file when Blender adapters run, reducing manual export steps.
 - The STEP exporter now reads window materials from the underlying `Window` instances.
 - Standard materials (`Stahl`, `Aluminium`, `Glas`, `Polymer`) are provided in the data model and can be selected via CLI parameters for decks and the hull. Exporters propagate these selections to STEP and glTF outputs.
+
+## 1.5 Scene configuration
+
+- A new `SceneConfiguration` dataclass defines boolean `include_<module>` flags for transport,
+  energy, safety, docking, propulsion and life support modules.
+- `SceneModel` wraps `StationModel` together with this configuration and exposes enabled
+  modules via `enabled_modules()`. The approach keeps the schema extensible for future
+  sub-systems.

--- a/simulations/full_scene.sample.toml
+++ b/simulations/full_scene.sample.toml
@@ -1,0 +1,8 @@
+# Sample configuration for a full station scene.
+# Each flag enables an optional subsystem module.
+include_transport = true
+include_energy = false
+include_safety = false
+include_docking = false
+include_propulsion = false
+include_life_support = true

--- a/simulations/sphere_space_station_simulations/data_model.py
+++ b/simulations/sphere_space_station_simulations/data_model.py
@@ -155,3 +155,23 @@ class StationModel:
     docking_ports: List[DockingPort] = field(default_factory=list)
     hull: Optional[Hull] = None
     wormhole: Optional[Wormhole] = None
+
+
+@dataclass
+class SceneConfiguration:
+    """Flags controlling optional sub-systems in a full station scene."""
+
+    include_transport: bool = False
+    include_energy: bool = False
+    include_safety: bool = False
+    include_docking: bool = False
+    include_propulsion: bool = False
+    include_life_support: bool = False
+
+    def included_modules(self) -> List[str]:
+        """Return a list of enabled module names without the ``include_`` prefix."""
+        return [
+            name.removeprefix("include_")
+            for name, value in vars(self).items()
+            if name.startswith("include_") and value
+        ]

--- a/simulations/sphere_space_station_simulations/scene_model.py
+++ b/simulations/sphere_space_station_simulations/scene_model.py
@@ -1,0 +1,28 @@
+"""Scene model linking base station geometry with optional modules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from .data_model import StationModel, SceneConfiguration
+
+
+@dataclass
+class SceneModel:
+    """Complete station scene with optional modules.
+
+    Attributes:
+        station: Base geometry of the station including decks, hull, wormhole and base rings.
+        config: Flags indicating which optional modules are included.
+
+    Additional modules can be added by extending :class:`SceneConfiguration`
+    with new ``include_<module>`` fields.
+    """
+
+    station: StationModel = field(default_factory=StationModel)
+    config: SceneConfiguration = field(default_factory=SceneConfiguration)
+
+    def enabled_modules(self) -> List[str]:
+        """List names of modules enabled in the configuration."""
+        return self.config.included_modules()


### PR DESCRIPTION
## Summary
- introduce `SceneConfiguration` dataclass with include flags for optional modules
- add `SceneModel` wrapper that lists enabled modules
- document scene configuration and provide sample config

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/data_model.py simulations/sphere_space_station_simulations/scene_model.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/data_model.py simulations/sphere_space_station_simulations/scene_model.py`
- `pytest simulations/tests`


------
https://chatgpt.com/codex/tasks/task_e_6894d41bfad0832a94769fdeffd82d13