### PR TITLE
feat: add selective publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,80 @@
+name: Selective Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'publish/**'
+
+jobs:
+  selective-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Python + YAML tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip
+          pip3 install pyyaml
+
+      - name: Get changed files
+        run: |
+          echo "CHANGED_FILES<<EOF" >> $GITHUB_ENV
+          git diff --name-only ${{ github.event.before }} ${{ github.sha }} >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Run selective publish
+        run: |
+          mkdir -p publish/
+
+          echo "Parsing publish.yml..."
+          python3 <<'PYTHON'
+import os
+import yaml
+
+changed_files = os.environ['CHANGED_FILES'].splitlines()
+
+with open('publish.yml') as f:
+    entries = yaml.safe_load(f)['publish']
+
+for entry in entries:
+    path = entry['path']
+    out = entry['out']
+    type_ = entry['type']
+
+    relevant_change = any(
+        changed == path or changed.startswith(path + '/') for changed in changed_files
+    )
+
+    if relevant_change:
+        print(f"\u2705 \u00c4nderungen erkannt bei: {path} \u2192 Generiere {out}")
+        if type_ == 'file':
+            os.system(f'cp {path} publish/{out}')
+        elif type_ == 'folder':
+            with open('temp_combined.md', 'w') as outfile:
+                for root, _, files in os.walk(path):
+                    for fname in sorted(files):
+                        if fname.endswith('.md'):
+                            with open(os.path.join(root, fname)) as infile:
+                                outfile.write(infile.read() + '\n\n')
+            os.system('mv temp_combined.md publish/' + out)
+    else:
+        print(f"\u2139\ufe0f Keine \u00c4nderungen bei: {path} \u2192 \u00dcberspringe {out}")
+PYTHON
+
+      - name: Commit and push changes
+        run: |
+          if [[ -n "$(git status --porcelain publish)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add publish
+            git commit -m "chore: update published artifacts" || true
+            git push
+          else
+            echo "No publish changes to commit."

--- a/publish.yml
+++ b/publish.yml
@@ -1,0 +1,8 @@
+publish:
+  - type: folder
+    path: documents
+    out: documents.md
+
+  - type: file
+    path: readme.md
+    out: README.md

--- a/publish/README.md
+++ b/publish/README.md
@@ -1,0 +1,3 @@
+# publish
+
+Generated documents are stored in this directory by the selective publish workflow.


### PR DESCRIPTION
## Summary
- add workflow to selectively publish changed paths from `publish.yml`
- provide example `publish.yml`
- document purpose of `publish` directory

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894ee79c844832a9c088bd7bf37d283