### PR TITLE
fix: correct publisher workflow indentation

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,1 @@
+GitHub configuration files and workflows.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,1 @@
+Continuous integration and publishing workflows for the project.

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -59,120 +59,119 @@ jobs:
           mkdir -p publish
 
           python3 <<'PY'
-import os, subprocess, sys, tempfile, yaml, shutil, pathlib, re
+          import os, subprocess, sys, tempfile, yaml, shutil, pathlib, re
 
-changed_files = os.environ.get("CHANGED_FILES","").splitlines()
+          changed_files = os.environ.get("CHANGED_FILES","").splitlines()
 
-def load_manifest():
-    # Unterstütze publish.yaml (Standard) und Fallback publish.yml
-    for fname in ("publish.yaml", "publish.yml"):
-        if os.path.exists(fname):
-            with open(fname, "r", encoding="utf-8") as f:
-                data = yaml.safe_load(f) or {}
-            pubs = data.get("publish", [])
-            if not isinstance(pubs, list):
-                print("⚠ 'publish' ist nicht als Liste definiert.")
-                sys.exit(1)
-            return pubs, fname
-    print("❌ Keine publish.yaml oder publish.yml im Repo gefunden.")
-    sys.exit(1)
+          def load_manifest():
+              # Unterstütze publish.yaml (Standard) und Fallback publish.yml
+              for fname in ("publish.yaml", "publish.yml"):
+                  if os.path.exists(fname):
+                      with open(fname, "r", encoding="utf-8") as f:
+                          data = yaml.safe_load(f) or {}
+                      pubs = data.get("publish", [])
+                      if not isinstance(pubs, list):
+                          print("⚠ 'publish' ist nicht als Liste definiert.")
+                          sys.exit(1)
+                      return pubs, fname
+              print("❌ Keine publish.yaml oder publish.yml im Repo gefunden.")
+              sys.exit(1)
 
-def has_relevant_change(path: str) -> bool:
-    path = path.rstrip("/").replace("\\","/")
-    for cf in changed_files:
-        cf = cf.replace("\\","/")
-        if cf == path or cf.startswith(f"{path}/"):
-            return True
-    return False
+          def has_relevant_change(path: str) -> bool:
+              path = path.rstrip("/").replace("\\","/")
+              for cf in changed_files:
+                  cf = cf.replace("\\","/")
+                  if cf == path or cf.startswith(f"{path}/"):
+                      return True
+              return False
 
-def normalize_markdown(text: str) -> str:
-    # Ersetze Unicode-Indices durch LaTeX-Form (z.B. ₂ -> $_2$)
-    subs = {"₀":"$_0$","₁":"$_1$","₂":"$_2$","₃":"$_3$","₄":"$_4$",
-            "₅":"$_5$","₆":"$_6$","₇":"$_7$","₈":"$_8$","₉":"$_9$"}
-    return "".join(subs.get(ch, ch) for ch in text)
+          def normalize_markdown(text: str) -> str:
+              # Ersetze Unicode-Indices durch LaTeX-Form (z.B. ₂ -> $_2$)
+              subs = {"₀":"$_0$","₁":"$_1$","₂":"$_2$","₃":"$_3$","₄":"$_4$",
+                      "₅":"$_5$","₆":"$_6$","₇":"$_7$","₈":"$_8$","₉":"$_9$"}
+              return "".join(subs.get(ch, ch) for ch in text)
 
-def run_pandoc(md_path: str, pdf_out: str):
-    pathlib.Path(os.path.dirname(pdf_out)).mkdir(parents=True, exist_ok=True)
-    cmd = [
-        "pandoc", md_path, "-o", pdf_out,
-        "--pdf-engine", "lualatex",
-        "-V", "mainfont=DejaVu Sans",
-        "-V", "monofont=DejaVu Sans Mono",
-        "-V", "emoji=OpenMoji-black-glyf.ttf",
-        "--lua-filter=latex-emoji.lua",
-        "-M", "emojifont=OpenMoji-black-glyf.ttf",
-        "-M", "color=false"
-    ]
-    print("→ Pandoc:", " ".join(cmd))
-    subprocess.check_call(cmd)
+          def run_pandoc(md_path: str, pdf_out: str):
+              pathlib.Path(os.path.dirname(pdf_out)).mkdir(parents=True, exist_ok=True)
+              cmd = [
+                  "pandoc", md_path, "-o", pdf_out,
+                  "--pdf-engine", "lualatex",
+                  "-V", "mainfont=DejaVu Sans",
+                  "-V", "monofont=DejaVu Sans Mono",
+                  "-V", "emoji=OpenMoji-black-glyf.ttf",
+                  "--lua-filter=latex-emoji.lua",
+                  "-M", "emojifont=OpenMoji-black-glyf.ttf",
+                  "-M", "color=false"
+              ]
+              print("→ Pandoc:", " ".join(cmd))
+              subprocess.check_call(cmd)
 
-def convert_file(md_file: str, pdf_out: str):
-    if not os.path.exists(md_file):
-        print(f"⚠ Datei nicht gefunden: {md_file}")
-        return
-    with open(md_file, "r", encoding="utf-8") as f:
-        content = normalize_markdown(f.read())
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as tmp:
-        tmp.write(content)
-        tmp_md = tmp.name
-    try:
-        run_pandoc(tmp_md, pdf_out)
-    finally:
-        try: os.unlink(tmp_md)
-        except: pass
+          def convert_file(md_file: str, pdf_out: str):
+              if not os.path.exists(md_file):
+                  print(f"⚠ Datei nicht gefunden: {md_file}")
+                  return
+              with open(md_file, "r", encoding="utf-8") as f:
+                  content = normalize_markdown(f.read())
+              with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as tmp:
+                  tmp.write(content)
+                  tmp_md = tmp.name
+              try:
+                  run_pandoc(tmp_md, pdf_out)
+              finally:
+                  try: os.unlink(tmp_md)
+                  except: pass
 
-def convert_folder(folder: str, pdf_out: str):
-    if not os.path.isdir(folder):
-        print(f"⚠ Ordner nicht gefunden: {folder}")
-        return
-    parts = []
-    for root, _, files in os.walk(folder):
-        for fname in sorted(files):
-            if fname.lower().endswith((".md",".markdown")):
-                fpath = os.path.join(root, fname)
-                with open(fpath, "r", encoding="utf-8") as f:
-                    parts.append(normalize_markdown(f.read()))
-    if not parts:
-        print(f"ℹ Keine Markdown-Dateien in {folder} gefunden – PDF wird übersprungen.")
-        return
-    combined = "\n\n\\newpage\n\n".join(parts)
-    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as tmp:
-        tmp.write(combined)
-        tmp_md = tmp.name
-    try:
-        run_pandoc(tmp_md, pdf_out)
-    finally:
-        try: os.unlink(tmp_md)
-        except: pass
+          def convert_folder(folder: str, pdf_out: str):
+              if not os.path.isdir(folder):
+                  print(f"⚠ Ordner nicht gefunden: {folder}")
+                  return
+              parts = []
+              for root, _, files in os.walk(folder):
+                  for fname in sorted(files):
+                      if fname.lower().endswith((".md",".markdown")):
+                          fpath = os.path.join(root, fname)
+                          with open(fpath, "r", encoding="utf-8") as f:
+                              parts.append(normalize_markdown(f.read()))
+              if not parts:
+                  print(f"ℹ Keine Markdown-Dateien in {folder} gefunden – PDF wird übersprungen.")
+                  return
+              combined = "\n\n\\newpage\n\n".join(parts)
+              with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False, encoding="utf-8") as tmp:
+                  tmp.write(combined)
+                  tmp_md = tmp.name
+              try:
+                  run_pandoc(tmp_md, pdf_out)
+              finally:
+                  try: os.unlink(tmp_md)
+                  except: pass
 
-entries, manifest_name = load_manifest()
-print(f"✓ Manifest geladen: {manifest_name}")
+          entries, manifest_name = load_manifest()
+          print(f"✓ Manifest geladen: {manifest_name}")
 
-for entry in entries:
-    path = (entry or {}).get("path")
-    out  = (entry or {}).get("out")
-    typ  = (entry or {}).get("type")
-    if not path or not out or not typ:
-        print(f"⚠ Ungültiger Eintrag übersprungen: {entry}")
-        continue
+          for entry in entries:
+              path = (entry or {}).get("path")
+              out  = (entry or {}).get("out")
+              typ  = (entry or {}).get("type")
+              if not path or not out or not typ:
+                  print(f"⚠ Ungültiger Eintrag übersprungen: {entry}")
+                  continue
 
-    relevant = has_relevant_change(path)
-    if not relevant:
-        print(f"ℹ Keine Änderungen in «{path}» → Überspringe «{out}»")
-        continue
+              relevant = has_relevant_change(path)
+              if not relevant:
+                  print(f"ℹ Keine Änderungen in «{path}» → Überspringe «{out}»")
+                  continue
 
-    pdf_out = os.path.join("publish", out)
-    print(f"✔ Änderungen in «{path}» → Erzeuge PDF «{pdf_out}»")
+              pdf_out = os.path.join("publish", out)
+              print(f"✔ Änderungen in «{path}» → Erzeuge PDF «{pdf_out}»")
 
-    if typ == "file":
-        # Erwartet Markdown-Eingaben; andere Dateitypen werden versucht, aber evtl. scheitern.
-        convert_file(path, pdf_out)
-    elif typ == "folder":
-        convert_folder(path, pdf_out)
-    else:
-        print(f"⚠ Unbekannter Typ «{typ}» für {path} – übersprungen.")
-
-PY
+              if typ == "file":
+                  # Erwartet Markdown-Eingaben; andere Dateitypen werden versucht, aber evtl. scheitern.
+                  convert_file(path, pdf_out)
+              elif typ == "folder":
+                  convert_folder(path, pdf_out)
+              else:
+                  print(f"⚠ Unbekannter Typ «{typ}» für {path} – übersprungen.")
+          PY
 
       - name: Commit and push generated PDFs
         shell: bash


### PR DESCRIPTION
## Summary
- fix indentation for embedded Python script in publisher workflow
- add README files for GitHub config directories

## Testing
- `python - <<'PY'
import yaml,sys;yaml.safe_load(open('.github/workflows/publisher.yml'));print('YAML valid')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6894fa77724c832a81075b849d8f00c2