### PR TITLE
chore: correct document history dates

### DIFF
--- a/documents/change-management/0001-initial-english-translation.md
+++ b/documents/change-management/0001-initial-english-translation.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: Project_SpaceBall_20230318.pdf
 ---

--- a/documents/partial-concepts/deck-concept-of-the-sphere-space-station-earth-one.md
+++ b/documents/partial-concepts/deck-concept-of-the-sphere-space-station-earth-one.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: documents/change-management/0001-initial-english-translation.md
 ---

--- a/documents/partial-concepts/earth-one-overview.md
+++ b/documents/partial-concepts/earth-one-overview.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: documents/change-management/0001-initial-english-translation.md
 ---

--- a/documents/partial-concepts/economic-feasibility-earth-one.md
+++ b/documents/partial-concepts/economic-feasibility-earth-one.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: documents/change-management/0001-initial-english-translation.md
 ---

--- a/documents/partial-concepts/readme.md
+++ b/documents/partial-concepts/readme.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: documents/change-management/0001-initial-english-translation.md
 ---

--- a/documents/partial-concepts/window-specification-earth-one-station.md
+++ b/documents/partial-concepts/window-specification-earth-one-station.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: documents/change-management/0001-initial-english-translation.md
 ---

--- a/documents/readme.md
+++ b/documents/readme.md
@@ -5,7 +5,7 @@ owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
   - version: 1.0.0
-    date: 2024-06-01
+    date: 2025-08-03
     change: "Initial"
     reference: Project_SpaceBall_20230318.pdf
 ---


### PR DESCRIPTION
## Summary
- correct document history dates to match first commit on 2025-08-03

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895cfec9ba0832aaf879e24463d789c