### PR TITLE
fix: correct skip directory check in gitbook workflow

### DIFF
--- a/.github/workflows/gitbook-style.yml
+++ b/.github/workflows/gitbook-style.yml
@@ -38,7 +38,7 @@ jobs:
           for root, dirs, files in os.walk(ROOT, topdown=True):
               # prune directories
               rel = Path(root).relative_to(ROOT)
-              if any(p.name in SKIP_DIRS for p in rel.parts):
+              if any(p in SKIP_DIRS for p in rel.parts):
                   dirs[:] = []
                   continue
               # filter & normalize directory names first


### PR DESCRIPTION
## Summary
- avoid AttributeError when renaming files for GitBook

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897472703b0832a8127948b38727a33