### PR TITLE
feat: add contradiction detection to QA pipeline

### DIFF
--- a/tests/qa/test_consistency.py
+++ b/tests/qa/test_consistency.py
@@ -1,0 +1,30 @@
+import pytest
+
+from tools.qa.consistency import find_contradictions
+from tools.qa.pipeline import run_pipeline
+
+
+def test_no_contradictions():
+    doc_a = {"max_load": 1000, "min_temp": -50}
+    doc_b = {"max_load": 1000, "min_temp": -50}
+    assert find_contradictions(doc_a, doc_b) is True
+
+
+def test_detects_contradictions():
+    doc_a = {"max_load": 1000, "min_temp": -50}
+    doc_b = {"max_load": 900, "min_temp": -50}
+    with pytest.raises(ValueError):
+        find_contradictions(doc_a, doc_b)
+
+
+def test_pipeline_detects_chapter_contradictions():
+    document = {
+        "max_load": 1000,
+        "min_temp": -50,
+        "chapters": [
+            {"max_load": 1000, "min_temp": -50},
+            {"max_load": 900, "min_temp": -50},
+        ],
+    }
+    with pytest.raises(ValueError):
+        run_pipeline(document)

--- a/tools/qa/consistency.py
+++ b/tools/qa/consistency.py
@@ -1,0 +1,49 @@
+"""Consistency checking utilities for QA pipeline."""
+
+
+def _normalize_key(key):
+    """Normalize keys for semantic comparison.
+
+    Converts keys to lowercase and replaces spaces or hyphens with underscores
+    so that semantically equivalent keys can be matched.
+    """
+    return key.lower().replace("-", "_").replace(" ", "_")
+
+
+def _normalize_document(doc):
+    """Return a new dict with normalized keys for comparison."""
+    return {_normalize_key(k): v for k, v in doc.items()}
+
+
+def find_contradictions(doc_a, doc_b):
+    """Check for contradictory values between two documents.
+
+    Parameters
+    ----------
+    doc_a, doc_b : dict
+        Mappings of metric names to values. Keys are normalized in a
+        case-insensitive manner to support simple semantic comparisons.
+
+    Returns
+    -------
+    bool
+        ``True`` if no contradictions are found.
+
+    Raises
+    ------
+    ValueError
+        If conflicting values are detected for any shared keys.
+    """
+    normalized_a = _normalize_document(doc_a)
+    normalized_b = _normalize_document(doc_b)
+
+    contradictions = []
+
+    for key in normalized_a.keys() & normalized_b.keys():
+        if normalized_a[key] != normalized_b[key]:
+            contradictions.append(f"{key}: {normalized_a[key]} vs {normalized_b[key]}")
+
+    if contradictions:
+        raise ValueError("Contradictions found: " + "; ".join(contradictions))
+
+    return True

--- a/tools/qa/pipeline.py
+++ b/tools/qa/pipeline.py
@@ -1,6 +1,7 @@
 """Processing pipeline for QA tasks."""
 
 from .factual_accuracy import check_factual_accuracy
+from .consistency import find_contradictions
 
 
 def semantic_analysis(document):
@@ -11,5 +12,12 @@ def semantic_analysis(document):
 def run_pipeline(document):
     """Run QA pipeline on a document."""
     check_factual_accuracy(document)
+
+    # Consistency checks across chapters
+    chapters = document.get("chapters") or []
+    for i, chapter_a in enumerate(chapters):
+        for chapter_b in chapters[i + 1 :]:
+            find_contradictions(chapter_a, chapter_b)
+
     # Semantic Analysis
     return semantic_analysis(document)


### PR DESCRIPTION
## Summary
- add semantic contradiction detection utilities
- integrate chapter comparison into QA pipeline
- cover contradictory material data with regression tests

## Testing
- `python -m pytest tests/qa -q`


------
https://chatgpt.com/codex/tasks/task_e_68978d667d30832aa7b159ec90eb6f8d