### PR TITLE
Add safety scenario checks and documentation

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.9
+version: 1.3.10
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.10
+    date: 2025-08-14
+    change: "Added safety scenario simulation utility to QA tools"
   - version: 1.3.9
     date: 2025-08-13
     change: "Introduced SceneModel and configuration flags for optional modules"
@@ -86,3 +89,10 @@ No external sources used.
 - `SceneModel` wraps `StationModel` together with this configuration and exposes enabled
   modules via `enabled_modules()`. The approach keeps the schema extensible for future
   sub-systems.
+
+## 1.6 Safety scenario QA
+
+An internal QA utility `simulate_safety_scenarios` checks documentation for
+emergency preparedness regarding fire, radiation and pressure loss. It flags
+missing evacuation routes or redundant systems to align the project with the
+Preamble and international safety standards.

--- a/tests/qa/test_safety.py
+++ b/tests/qa/test_safety.py
@@ -1,0 +1,15 @@
+from tools.qa.safety import simulate_safety_scenarios
+
+
+def test_detect_missing_evacuation_route():
+    doc = "Fire suppression uses a redundant system for containment."
+    result = simulate_safety_scenarios(doc)
+    assert "fire" in result
+    assert "missing evacuation route" in result["fire"]
+
+
+def test_detect_missing_redundant_system():
+    doc = "Fire emergency plan includes an evacuation route for all decks."
+    result = simulate_safety_scenarios(doc)
+    assert "fire" in result
+    assert "missing redundant system" in result["fire"]

--- a/tools/qa/safety.py
+++ b/tools/qa/safety.py
@@ -1,0 +1,38 @@
+"""Safety scenario simulation utilities."""
+
+SCENARIOS = {
+    "fire": ["fire"],
+    "radiation": ["radiation"],
+    "pressure_loss": ["pressure loss", "decompression"],
+}
+
+
+def simulate_safety_scenarios(document):
+    """Check emergency preparedness for fire, radiation and pressure loss.
+
+    Parameters
+    ----------
+    document : str
+        Text describing safety procedures.
+
+    Returns
+    -------
+    dict
+        Mapping of scenario names to lists of detected issues. An empty
+        dictionary indicates no problems were found.
+    """
+    text = document.lower()
+    results = {}
+
+    for name, keywords in SCENARIOS.items():
+        issues = []
+        if not any(k in text for k in keywords):
+            issues.append("scenario not addressed")
+        if "evacuation route" not in text:
+            issues.append("missing evacuation route")
+        if "redundant system" not in text:
+            issues.append("missing redundant system")
+        if issues:
+            results[name] = issues
+
+    return results

--- a/tools/qa/safety_rules.yaml
+++ b/tools/qa/safety_rules.yaml
@@ -1,0 +1,12 @@
+preamble:
+  section: "0.1 Preamble — Ethics & Security"
+  criteria:
+    - "QA-4: Safety Compliance"
+
+international_standards:
+  fire:
+    - "NFPA 130: Standard for Fixed Guideway Transit and Passenger Rail Systems"
+  radiation:
+    - "IAEA Safety Standards for Radiation Protection"
+  pressure_loss:
+    - "ISO 14620-1:2011 Space systems — Safety requirements"


### PR DESCRIPTION
## Summary
- add YAML references to Preamble safety criteria and international standards
- introduce `simulate_safety_scenarios` to flag missing evacuation routes or redundant systems
- document safety QA tool in software design decisions and add unit tests

## Testing
- `PYTHONPATH=. pytest tests/qa/test_safety.py`
- `PYTHONPATH=. pytest tests/qa` *(fails: AssertionError in test_checklist.py)*

------
https://chatgpt.com/codex/tasks/task_e_68979e23c994832a87dd726f21fe7c71