### PR TITLE
Add source traceability check to QA pipeline

### DIFF
--- a/tests/qa/test_traceability.py
+++ b/tests/qa/test_traceability.py
@@ -1,0 +1,34 @@
+import pytest
+
+from tools.qa.traceability import link_sources
+from tools.qa.pipeline import run_pipeline
+
+
+def test_links_chapter_sources():
+    document = {
+        "chapters": [
+            {"number": "1", "sources": ["ISO"]},
+            {"number": "2", "sources": ["NASA"]},
+        ],
+        "external_sources": ["ISO", "NASA"],
+    }
+    mapping = link_sources(document)
+    assert mapping == {"1": ["ISO"], "2": ["NASA"]}
+
+
+def test_detects_unreferenced_source():
+    document = {
+        "chapters": [{"number": "1", "sources": ["ISO"]}],
+        "external_sources": ["ISO", "NASA"],
+    }
+    with pytest.raises(ValueError):
+        link_sources(document)
+
+
+def test_pipeline_flags_unreferenced_source():
+    document = {
+        "chapters": [{"number": "1", "sources": ["ISO"]}],
+        "external_sources": ["ISO", "NASA"],
+    }
+    with pytest.raises(ValueError):
+        run_pipeline(document)

--- a/tools/qa/pipeline.py
+++ b/tools/qa/pipeline.py
@@ -2,6 +2,7 @@
 
 from .factual_accuracy import check_factual_accuracy
 from .consistency import find_contradictions
+from .traceability import link_sources
 
 
 def semantic_analysis(document):
@@ -12,6 +13,9 @@ def semantic_analysis(document):
 def run_pipeline(document):
     """Run QA pipeline on a document."""
     check_factual_accuracy(document)
+
+    # Link chapters to external sources and verify references
+    document["source_links"] = link_sources(document)
 
     # Consistency checks across chapters
     chapters = document.get("chapters") or []

--- a/tools/qa/traceability.py
+++ b/tools/qa/traceability.py
@@ -1,0 +1,44 @@
+"""Utilities for linking document sections with external sources."""
+
+
+def link_sources(document):
+    """Link chapter numbers to external source identifiers.
+
+    Parameters
+    ----------
+    document : dict
+        Mapping describing the document. Expected keys are ``chapters`` and
+        ``external_sources``. Each chapter must provide a ``number`` and may
+        list referenced source identifiers in ``sources``.
+
+    Returns
+    -------
+    dict
+        Mapping of chapter numbers to lists of external source identifiers.
+
+    Raises
+    ------
+    ValueError
+        If any external source is not referenced by at least one chapter.
+    """
+    chapters = document.get("chapters", [])
+    external_sources = set(document.get("external_sources", []))
+
+    source_map = {}
+    referenced = set()
+
+    for chapter in chapters:
+        number = chapter.get("number")
+        if number is None:
+            raise ValueError("Chapter missing 'number'")
+        sources = chapter.get("sources", [])
+        source_map[number] = sources
+        referenced.update(sources)
+
+    missing = sorted(external_sources - referenced)
+    if missing:
+        raise ValueError(
+            "Unreferenced external sources: " + ", ".join(missing)
+        )
+
+    return source_map


### PR DESCRIPTION
## Summary
- Add `link_sources` utility to map chapter numbers to external sources and validate references
- Integrate traceability step into QA pipeline
- Test unreferenced external sources and pipeline integration

## Testing
- `PYTHONPATH=. pytest tests/qa/test_traceability.py`


------
https://chatgpt.com/codex/tasks/task_e_6897a080acc0832abc03dad0f3aa4380