### PR TITLE
Fix checklist completeness ordering

### DIFF
--- a/tools/qa/checklist.py
+++ b/tools/qa/checklist.py
@@ -48,9 +48,9 @@ def check_completeness(document, template):
     missing = {}
 
     for key in template:
-        required = set(template.get(key, []))
+        required_list = template.get(key, [])
         present = set(document.get(key, []))
-        absent = sorted(required - present)
+        absent = [item for item in required_list if item not in present]
         if absent:
             missing[key] = absent
 


### PR DESCRIPTION
## Summary
- preserve template-defined order of missing sections in `check_completeness`

## Testing
- `black --check tools/qa/checklist.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a3441e2c832a921fa763722dd402