### PR TITLE
Add QA pipeline with reporting

### DIFF
--- a/docs/qa/pipeline.md
+++ b/docs/qa/pipeline.md
@@ -1,0 +1,23 @@
+# QA Pipeline
+
+The QA pipeline runs a series of checks on a document and stores a report.
+
+## Schritte
+1. Import
+2. Pre-Check
+3. Semantic Analysis
+4. Safety Simulation
+5. Issue Tagging
+6. Report-Erstellung
+7. Review
+
+## Verwendung
+```python
+from tools.qa.pipeline import run_pipeline
+
+result = run_pipeline("document.json", presentation_format="pitch")
+print(result["report_path"])
+```
+
+Reports are written to `reports/qa/` with chapter references and
+issue categories.

--- a/reports/qa/readme.md
+++ b/reports/qa/readme.md
@@ -1,0 +1,3 @@
+# QA Reports
+
+Automated QA results with chapter references and categorization.

--- a/reports/readme.md
+++ b/reports/readme.md
@@ -1,0 +1,3 @@
+# Reports
+
+Generated quality assurance and other project reports.

--- a/tools/qa/pipeline.py
+++ b/tools/qa/pipeline.py
@@ -1,42 +1,141 @@
-"""Processing pipeline for QA tasks."""
+"""Quality assurance processing pipeline.
 
-from .factual_accuracy import check_factual_accuracy
+This module orchestrates the QA workflow consisting of:
+1. Import
+2. Pre-Check
+3. Semantic Analysis
+4. Safety Simulation
+5. Issue Tagging
+6. Report Creation
+7. Review
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from .checklist import CHECKLISTS, check_completeness
 from .consistency import find_contradictions
-from .traceability import link_sources
+from .factual_accuracy import check_factual_accuracy
 from .presentation import generate_pitch
+from .safety import simulate_safety_scenarios
+from .traceability import link_sources
 
 
-def semantic_analysis(document):
+# ---------------------------------------------------------------------------
+# Pipeline steps
+# ---------------------------------------------------------------------------
+
+def import_document(data_or_path: Any) -> dict:
+    """Import a document from a mapping or JSON file."""
+    if isinstance(data_or_path, (str, Path)):
+        with open(data_or_path, "r", encoding="utf-8") as handle:
+            return json.load(handle)
+    return data_or_path
+
+
+def pre_check(document: dict, template: str = "technical_report") -> dict:
+    """Check document completeness against a checklist template."""
+    checklist = CHECKLISTS.get(template, {})
+    return check_completeness(document, checklist)
+
+
+def semantic_analysis(document: dict) -> dict:
     """Placeholder for semantic analysis step."""
     return {"semantics": document.get("text", "")}
 
 
-def run_pipeline(document, presentation_format: str | None = None):
-    """Run QA pipeline on a document.
+def safety_simulation(document: dict) -> dict:
+    """Run safety scenario simulations on the document."""
+    return simulate_safety_scenarios(document.get("text", ""))
 
-    Parameters
-    ----------
-    document:
-        Mapping representing the document.
-    presentation_format:
-        If set to ``"pitch"`` an additional ``"pitch"`` entry is attached to
-        the returned data containing a bullet-point version of ``document``.
-    """
-    check_factual_accuracy(document)
 
-    # Link chapters to external sources and verify references
-    document["source_links"] = link_sources(document)
+def tag_issues(pre: dict, safety: dict) -> list[dict[str, str]]:
+    """Combine pre-check and safety results into tagged issues."""
+    issues: list[dict[str, str]] = []
+    for section, items in pre.items():
+        for item in items:
+            issues.append(
+                {
+                    "category": "pre_check",
+                    "reference": item,
+                    "description": f"missing {section[:-1]}",
+                }
+            )
+    for scenario, problems in safety.items():
+        issues.append(
+            {
+                "category": "safety",
+                "reference": scenario,
+                "description": ", ".join(problems),
+            }
+        )
+    return issues
 
-    # Consistency checks across chapters
-    chapters = document.get("chapters") or []
+
+def create_report(issues: list[dict[str, str]], output_dir: Path | None = None) -> Path:
+    """Write a QA report with chapter references and categorization."""
+    output_dir = output_dir or Path("reports/qa")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+    report_path = output_dir / f"qa-report-{timestamp}.md"
+    lines = ["# QA Report", ""]
+    for issue in issues:
+        lines.append(
+            f"- [{issue['category']}] {issue['reference']}: {issue['description']}"
+        )
+    with report_path.open("w", encoding="utf-8") as handle:
+        handle.write("\n".join(lines))
+    return report_path
+
+
+def review(report_path: Path) -> str:
+    """Return a review message for the generated report."""
+    return f"Report stored at {report_path}"
+
+
+# ---------------------------------------------------------------------------
+# Pipeline runner
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    document: Any,
+    presentation_format: str | None = None,
+    template: str = "technical_report",
+) -> dict:
+    """Run QA pipeline on a document."""
+    doc = import_document(document)
+
+    # Pre-existing QA checks
+    check_factual_accuracy(doc)
+    doc["source_links"] = link_sources(doc)
+
+    chapters = doc.get("chapters") or []
     for i, chapter_a in enumerate(chapters):
         for chapter_b in chapters[i + 1 :]:
             find_contradictions(chapter_a, chapter_b)
 
-    # Semantic Analysis
-    result = semantic_analysis(document)
+    # New pipeline steps
+    pre = pre_check(doc, template)
+    semantic = semantic_analysis(doc)
+    safety = safety_simulation(doc)
+    issues = tag_issues(pre, safety)
+    report_path = create_report(issues)
+    review_message = review(report_path)
+
+    result = {
+        "pre_check": pre,
+        "semantic": semantic,
+        "safety": safety,
+        "issues": issues,
+        "report_path": str(report_path),
+        "review": review_message,
+    }
 
     if presentation_format == "pitch":
-        result["pitch"] = generate_pitch(document, document.get("audience", "general"))
+        result["pitch"] = generate_pitch(doc, doc.get("audience", "general"))
 
     return result


### PR DESCRIPTION
## Summary
- implement full QA pipeline including import, pre-check, semantic analysis, safety simulation, issue tagging, report creation and review
- persist QA reports under `reports/qa` and document pipeline usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b06864d0832abb3a169a17ef1d39