### PR TITLE
refactor: update paths for tool resources

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -4,15 +4,21 @@ on:
   push:
     paths:
       - '**/*.md'
-      - 'docs/**'
+      - 'tools/docs/**'
       - 'documents/**'
       - 'project/**'
+      - 'tools/reports/**'
+      - 'tools/logs/**'
+      - 'tools/tests/**'
   pull_request:
     paths:
       - '**/*.md'
-      - 'docs/**'
+      - 'tools/docs/**'
       - 'documents/**'
       - 'project/**'
+      - 'tools/reports/**'
+      - 'tools/logs/**'
+      - 'tools/tests/**'
 
 jobs:
   qa:
@@ -27,4 +33,5 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run QA pipeline
-        run: pytest tests/qa -q
+        run: |
+          PYTHONPATH=. pytest tools/tests/qa -q

--- a/tools/docs/qa/pipeline.md
+++ b/tools/docs/qa/pipeline.md
@@ -19,5 +19,5 @@ result = run_pipeline("document.json", presentation_format="pitch")
 print(result["report_path"])
 ```
 
-Reports are written to `reports/qa/` with chapter references and
+Reports are written to `tools/reports/qa/` with chapter references and
 issue categories.

--- a/tools/qa/history.py
+++ b/tools/qa/history.py
@@ -8,7 +8,9 @@ from pathlib import Path
 from typing import List, Dict
 import shutil
 
-HISTORY_DIR = Path("reports/qa/history")
+HISTORY_DIR = (
+    Path(__file__).resolve().parent.parent / "reports" / "qa" / "history"
+)
 HISTORY_FILE = HISTORY_DIR / "history.json"
 
 

--- a/tools/qa/pipeline.py
+++ b/tools/qa/pipeline.py
@@ -79,7 +79,10 @@ def tag_issues(pre: dict, safety: dict) -> list[dict[str, str]]:
 
 def create_report(issues: list[dict[str, str]], output_dir: Path | None = None) -> Path:
     """Write a QA report with chapter references and categorization."""
-    output_dir = output_dir or Path("reports/qa")
+    output_dir = (
+        output_dir
+        or Path(__file__).resolve().parent.parent / "reports" / "qa"
+    )
     output_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
     report_path = output_dir / f"qa-report-{timestamp}.md"

--- a/tools/qa/safety.py
+++ b/tools/qa/safety.py
@@ -10,7 +10,7 @@ from typing import Dict, List
 # logging configuration
 # ---------------------------------------------------------------------------
 
-LOG_DIR = Path(__file__).resolve().parents[2] / "logs" / "safety"
+LOG_DIR = Path(__file__).resolve().parent.parent / "logs" / "safety"
 LOG_DIR.mkdir(parents=True, exist_ok=True)
 LOG_FILE = LOG_DIR / "audit.log"
 


### PR DESCRIPTION
## Summary
- update QA workflow paths for docs, reports, logs and tests
- fix QA modules to use new tools-based directories
- document new report location

## Testing
- `PYTHONPATH=. pytest tools/tests/qa -q`


------
https://chatgpt.com/codex/tasks/task_e_68984c145240832a9698567317accc79