### PR TITLE
fix: update technical overview paths

### DIFF
--- a/documents/07-comprehensive-technical-documentation/7.1-sphere-station-documentation-technical-and-operational-overview.md
+++ b/documents/07-comprehensive-technical-documentation/7.1-sphere-station-documentation-technical-and-operational-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Sphere Station Documentation: Technical and Operational Overview"
-version: 1.0.0
+version: 1.0.1
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
@@ -8,6 +8,10 @@ history:
     date: 2024-10-30
     change: "Initial"
     reference: Project_SpaceBall_20230318.pdf
+  - version: 1.0.1
+    date: 2025-08-03
+    change: "Bring the Single Source of Truth Documents into GitBook Format"
+    reference: https://github.com/robert2100-08-16/Sphere-Space-Station-Earth-ONE-and-Beyond/documents/7.3.2-bring-the-single-source-of-truth-documents-into-gitbook-format
 ---
 
 ## 7.1 Sphere Station Documentation: Technical and Operational Overview
@@ -22,16 +26,16 @@ history:
 
 This overview links to the detailed documentation for the Sphere Station project.
 
-1. [Technical Design and System Specifications](technical-design-and-system-specifications.md)
-2. [Staffing, Facilities, and Living Spaces](staffing-facilities-and-living-spaces.md)
-3. [Energy and Thermal Management Systems](energy-and-thermal-management-systems.md)
-4. [Organizational Structure and Consortium Model](organizational-structure-and-consortium-model.md)
-5. [Public Engagement and Decentralized Associations](public-engagement-and-decentralized-associations.md)
-6. [Economic Feasibility and Market Analysis](economic-feasibility-and-market-analysis.md)
-7. [Environmental and Sustainability Goals](environmental-and-sustainability-goals.md)
-8. [Future Expansion of the Sphere Station Network and Sphere Space Crafts](future-expansion-of-the-sphere-station-network-and-sphere-space-crafts.md)
-9. [Establishing a Solar Alliance for Governance and Security in Space](establishing-a-solar-alliance-for-governance-and-security-in-space.md)
-10. [Self-Sustainability Models for Space Stations and Spacecraft](self-sustainability-models-for-space-stations-and-spacecraft.md)
+1. [Technical Design and System Specifications](../02-technical-foundations/2.1-technical-design-and-system-specifications.md)
+2. [Staffing, Facilities, and Living Spaces](../03-infrastructure-and-operations/3.1-staffing-facilities-and-living-spaces.md)
+3. [Energy and Thermal Management Systems](../02-technical-foundations/2.3-energy-and-thermal-management-systems.md)
+4. [Organizational Structure and Consortium Model](../03-infrastructure-and-operations/3.2-organizational-structure-and-consortium-model.md)
+5. [Public Engagement and Decentralized Associations](../03-infrastructure-and-operations/3.3-public-engagement-and-decentralized-associations.md)
+6. [Economic Feasibility and Market Analysis](../04-sustainability-and-economic-viability/4.3-economic-feasibility-and-market-analysis.md)
+7. [Environmental and Sustainability Goals](../04-sustainability-and-economic-viability/4.1-environmental-and-sustainability-goals.md)
+8. [Future Expansion of the Sphere Station Network and Sphere Space Crafts](../06-expansion-and-future-projects/6.1-future-expansion-of-the-sphere-station-network-and-sphere-space-crafts.md)
+9. [Establishing a Solar Alliance for Governance and Security in Space](../05-security-governance-and-alliances/5.1-establishing-a-solar-alliance-for-governance-and-security-in-space.md)
+10. [Self-Sustainability Models for Space Stations and Spacecraft](../04-sustainability-and-economic-viability/4.2-self-sustainability-models-for-space-stations-and-spacecraft.md)
 
 ### 7.1.1 Sources
 


### PR DESCRIPTION
## Summary
- fix broken cross-document links in technical overview for GitBook
- note GitBook migration in overview change log

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68985ea3b350832abdd864ce291b3b6a