### PR TITLE
fix: allow ensure-readme workflow to trigger actions

### DIFF
--- a/.github/workflows/ensure-readme.yml
+++ b/.github/workflows/ensure-readme.yml
@@ -39,7 +39,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "chore: add missing readme.md files [skip ci]"
+            git commit -m "chore: add missing readme.md files"
             git push
           else
             echo "No missing readme.md files found."


### PR DESCRIPTION
## Summary
- remove `[skip ci]` from ensure-readme workflow commits so future changes trigger full CI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68987006d4e4832a839a7817dbf90d24