### PR TITLE
Add DECK000 EV0 geometry exporter and documentation

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/02-engineering/02-concepts/construction-handbook.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/02-engineering/02-concepts/construction-handbook.md
@@ -1,9 +1,12 @@
 ---
 title: "Construction Handbook"
-version: 1.1.1
+version: 1.1.2
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.1.2
+    date: 2025-08-15
+    change: "Documented DECK000 EV0 geometry export"
   - version: 1.1.1
     date: 2025-08-10
     change: "Corrected window material handling in STEP exporter"
@@ -30,6 +33,7 @@ This handbook collects key decisions for modeling the Sphere Space Station and s
 - **Hull simulation**: An additional script `adapter.py` creates a simplified outer hull. A dedicated VS Code launch entry makes it easy to test the script.
 - **Blender helpers** reside in the subpackage `blender_helpers` and are imported by the adapter.
 - **Hull geometry** is computed by `geometry/hull.py` and imported by the deck logic.
+- **Deck evolution modules**: EV0 adds baseline DECK000 tube segments with OBJ+CSV export.
 - **Deck supports and docking ports** can be parametrized in `SphereDeckCalculator`,
   enriching the structural model with columns and equatorial docking locations.
 - **Station simulation** has moved to `simulation.py` and can be started directly from the library. `run_simulation.py` is now called `starter.py`.

--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.10
+version: 1.3.11
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.11
+    date: 2025-08-15
+    change: "Introduced EV0 deck module for axial tube geometry"
   - version: 1.3.10
     date: 2025-08-14
     change: "Added safety scenario simulation utility to QA tools"
@@ -96,3 +99,7 @@ An internal QA utility `simulate_safety_scenarios` checks documentation for
 emergency preparedness regarding fire, radiation and pressure loss. It flags
 missing evacuation routes or redundant systems to align the project with the
 Preamble and international safety standards.
+
+## 1.7 Deck evolution modules
+
+- EV0 module generates DECK000 axial tube geometry and exports OBJ and CSV reports.

--- a/simulations/sphere_space_station_simulations/evolutions/__init__.py
+++ b/simulations/sphere_space_station_simulations/evolutions/__init__.py
@@ -1,0 +1,14 @@
+"""
+Evolutions namespace for Sphere Space Station geometry.
+
+EVOLUTION 0:
+ - Minimal, CAD-freundliche Volumendarstellung der DECK000-Röhre
+ - Ohne Boolesche Fenster-Ausschnitte (Fenster später in EV1)
+"""
+
+__all__ = [
+    "evo0_deck000",
+]
+
+# Import side-effect free
+from . import evo0_deck000  # noqa: F401

--- a/simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py
+++ b/simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py
@@ -1,0 +1,351 @@
+"""
+EVOLUTION 0 – DECK000 'Wormhole' baseline CAD geometry.
+
+Generates a segmented axial tube with:
+ - Overall length: 127 m
+ - Barrel: OD 22 m, ID 20 m
+ - Six docking-ring modules: 10 m axial length, ID 10 m (constricted throat), OD flush (22 m)
+ - Start of first ring at 3.5 m from the North pole interior face
+ - Ring pitch 20 m; window-tube modules (10 m) between rings
+ - 3.5 m service clearances at both ends
+
+EV0 deliberately keeps window cutouts as TODO (no boolean subtractions), focusing on
+structural barrels + rings to enable fast CAD import and downstream detailing (EV1+).
+
+Exports:
+ - OBJ mesh (watertight shell segments per module)
+ - CSV segment table (Table 1 equivalent)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple, Dict
+import math
+import csv
+
+# -------------------------
+# Parameters & segment plan
+# -------------------------
+
+
+@dataclass(frozen=True)
+class Deck000Params:
+    length: float = 127.0
+    barrel_od: float = 22.0
+    barrel_id: float = 20.0
+    ring_id: float = 10.0
+    ring_len: float = 10.0
+    window_len: float = 10.0
+    ring_first_offset: float = 3.5
+    ring_pitch: float = 20.0
+    n_rings: int = 6  # 00..05
+    end_clearance: float = 3.5
+    radial_segments: int = 96  # circle tessellation
+
+    @property
+    def barrel_ro(self) -> float:
+        return self.barrel_od * 0.5
+
+    @property
+    def barrel_ri(self) -> float:
+        return self.barrel_id * 0.5
+
+    @property
+    def ring_ri(self) -> float:
+        return self.ring_id * 0.5
+
+
+def generate_segments(p: Deck000Params) -> List[Dict]:
+    """
+    Generate Table-1-like segment list from North (z=0) to South (z=length).
+    Segment types: 'clearance', 'ring', 'window'
+    """
+    segments: List[Dict] = []
+
+    # North clearance
+    z = 0.0
+    if p.end_clearance > 0:
+        segments.append(
+            dict(
+                name="clearance_north",
+                type="clearance",
+                z0=0.0,
+                z1=p.end_clearance,
+                r_inner=p.barrel_ri,
+                r_outer=p.barrel_ro,
+                note="forward clearance / taper / systems",
+            )
+        )
+        z = p.end_clearance
+
+    # Alternating ring / window modules
+    for i in range(p.n_rings):
+        # Position of ring i
+        ring_z0 = p.ring_first_offset + i * p.ring_pitch
+        ring_z1 = ring_z0 + p.ring_len
+        # Window before/after depending on sequence:
+        # The baseline has a 10 m 'window tube' between rings.
+        # We add the window segment that precedes the next ring (except before the very first ring).
+        if i == 0:
+            # Immediately add the first ring (3.5..13.5)
+            segments.append(
+                dict(
+                    name=f"ring_{i:02d}",
+                    type="ring",
+                    z0=ring_z0,
+                    z1=ring_z1,
+                    r_inner=p.ring_ri,
+                    r_outer=p.barrel_ro,
+                    note="Inconel ring, constricted ID",
+                )
+            )
+        else:
+            # Window segment from end of previous ring to start of this ring
+            prev_ring_z1 = p.ring_first_offset + (i - 1) * p.ring_pitch + p.ring_len
+            segments.append(
+                dict(
+                    name=f"window_{i-1:02d}",
+                    type="window",
+                    z0=prev_ring_z1,
+                    z1=ring_z0,
+                    r_inner=p.barrel_ri,
+                    r_outer=p.barrel_ro,
+                    note="window tube (apertures to be detailed in EV1)",
+                )
+            )
+            # This ring
+            segments.append(
+                dict(
+                    name=f"ring_{i:02d}",
+                    type="ring",
+                    z0=ring_z0,
+                    z1=ring_z1,
+                    r_inner=p.ring_ri,
+                    r_outer=p.barrel_ro,
+                    note="Inconel ring, constricted ID",
+                )
+            )
+
+    # Window after last ring up to (length - clearance)
+    last_ring_z1 = p.ring_first_offset + (p.n_rings - 1) * p.ring_pitch + p.ring_len
+    tail_z1 = p.length - p.end_clearance
+    if tail_z1 > last_ring_z1:
+        segments.append(
+            dict(
+                name=f"window_{p.n_rings:02d}",
+                type="window",
+                z0=last_ring_z1,
+                z1=tail_z1,
+                r_inner=p.barrel_ri,
+                r_outer=p.barrel_ro,
+                note="window tube (apertures to be detailed in EV1)",
+            )
+        )
+
+    # South clearance
+    if p.end_clearance > 0:
+        segments.append(
+            dict(
+                name="clearance_south",
+                type="clearance",
+                z0=tail_z1,
+                z1=p.length,
+                r_inner=p.barrel_ri,
+                r_outer=p.barrel_ro,
+                note="aft clearance / taper / systems",
+            )
+        )
+
+    return segments
+
+
+# -------------------------
+# Simple mesh primitives
+# -------------------------
+
+
+class Mesh:
+    __slots__ = ("name", "vertices", "faces")
+
+    def __init__(self, name: str):
+        self.name = name
+        self.vertices: List[Tuple[float, float, float]] = []
+        self.faces: List[Tuple[int, int, int]] = []
+
+    def merge(self, other: "Mesh") -> None:
+        offset = len(self.vertices)
+        self.vertices.extend(other.vertices)
+        self.faces.extend(
+            [(a + offset, b + offset, c + offset) for (a, b, c) in other.faces]
+        )
+
+
+def tube_segment(
+    name: str,
+    z0: float,
+    z1: float,
+    r_inner: float,
+    r_outer: float,
+    radial_segments: int,
+) -> Mesh:
+    """
+    Create a hollow cylindrical shell between z0 and z1.
+    - Outer and inner skins (no end caps for contiguous assembly)
+    """
+    m = Mesh(name)
+    n = radial_segments
+    two_pi = 2.0 * math.pi
+
+    # Outer ring vertices at z0 and z1
+    vo0 = []
+    vo1 = []
+    for i in range(n):
+        a = two_pi * i / n
+        x = r_outer * math.cos(a)
+        y = r_outer * math.sin(a)
+        vo0.append(len(m.vertices))
+        m.vertices.append((x, y, z0))
+        vo1.append(len(m.vertices))
+        m.vertices.append((x, y, z1))
+
+    # Inner ring vertices at z0 and z1 (clockwise reversed to keep outward normals outward-ish)
+    vi0 = []
+    vi1 = []
+    for i in range(n):
+        a = two_pi * i / n
+        x = r_inner * math.cos(a)
+        y = r_inner * math.sin(a)
+        vi0.append(len(m.vertices))
+        m.vertices.append((x, y, z0))
+        vi1.append(len(m.vertices))
+        m.vertices.append((x, y, z1))
+
+    # Quads -> triangles for outer skin
+    for i in range(n):
+        i_next = (i + 1) % n
+        a0 = vo0[i]
+        b0 = vo0[i_next]
+        a1 = vo1[i]
+        b1 = vo1[i_next]
+        # two triangles (a0, a1, b1) and (a0, b1, b0)
+        m.faces.append((a0, a1, b1))
+        m.faces.append((a0, b1, b0))
+
+    # Quads -> triangles for inner skin (flip winding)
+    for i in range(n):
+        i_next = (i + 1) % n
+        a0 = vi0[i]
+        b0 = vi0[i_next]
+        a1 = vi1[i]
+        b1 = vi1[i_next]
+        # flip winding to face inward (so normals 'inward' -> okay for CAD viewers)
+        m.faces.append((a0, b1, a1))
+        m.faces.append((a0, b0, b1))
+
+    return m
+
+
+def build_meshes_for_segments(segments: List[Dict], p: Deck000Params) -> List[Mesh]:
+    meshes: List[Mesh] = []
+    for seg in segments:
+        name = f"{seg['type']}-{seg['name']}"
+        meshes.append(
+            tube_segment(
+                name=name,
+                z0=seg["z0"],
+                z1=seg["z1"],
+                r_inner=seg["r_inner"],
+                r_outer=seg["r_outer"],
+                radial_segments=p.radial_segments,
+            )
+        )
+    return meshes
+
+
+# -------------------------
+# Exports (OBJ + CSV)
+# -------------------------
+
+
+def export_obj(meshes: List[Mesh], out_path: Path) -> None:
+    """
+    Write a single OBJ containing all meshes as named objects.
+    No MTL, no normals/UVs (CAD-friendly lightweight mesh).
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        f.write("# DECK000 EVOLUTION 0 – generated OBJ\n")
+        vert_offset = 1
+        for m in meshes:
+            f.write(f"o {m.name}\n")
+            for x, y, z in m.vertices:
+                f.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")
+            for a, b, c in m.faces:
+                f.write(f"f {a+vert_offset} {b+vert_offset} {c+vert_offset}\n")
+            vert_offset += len(m.vertices)
+
+
+def export_csv(segments: List[Dict], out_csv: Path) -> None:
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    with out_csv.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(
+            [
+                "Segment",
+                "Type",
+                "Axial start (m)",
+                "Axial end (m)",
+                "Axial length (m)",
+                "r_inner (m)",
+                "r_outer (m)",
+                "Notes",
+            ]
+        )
+        for seg in segments:
+            w.writerow(
+                [
+                    seg["name"],
+                    seg["type"],
+                    f"{seg['z0']:.3f}",
+                    f"{seg['z1']:.3f}",
+                    f"{(seg['z1']-seg['z0']):.3f}",
+                    f"{seg['r_inner']:.3f}",
+                    f"{seg['r_outer']:.3f}",
+                    seg.get("note", ""),
+                ]
+            )
+
+
+# -------------------------
+# High-level build entry
+# -------------------------
+
+
+def build_and_export_ev0(
+    out_dir: Path | str = "simulations/results/deck000_evo0",
+) -> Dict[str, Path]:
+    """
+    Generates EV0 geometry & reports into out_dir.
+    Returns dict with key artifacts.
+    """
+    out_dir = Path(out_dir)
+    p = Deck000Params()
+    segments = generate_segments(p)
+    meshes = build_meshes_for_segments(segments, p)
+
+    obj_path = out_dir / "deck000_ev0.obj"
+    csv_path = out_dir / "deck000_ev0_segments.csv"
+
+    export_obj(meshes, obj_path)
+    export_csv(segments, csv_path)
+
+    return {"obj": obj_path, "csv": csv_path}
+
+
+if __name__ == "__main__":
+    artifacts = build_and_export_ev0()
+    print("EVOLUTION 0 generated:")
+    for k, v in artifacts.items():
+        print(f" - {k}: {v}")

--- a/simulations/sphere_space_station_simulations/evolutions/readme.md
+++ b/simulations/sphere_space_station_simulations/evolutions/readme.md
@@ -1,0 +1,30 @@
+# Evolutions – DECK000
+
+**EVOLUTION 0** implements the baseline axial tube geometry for **DECK000**:
+
+- Length 127 m; barrel OD 22 m, ID 20 m  
+- Six docking rings (10 m each) with constricted **ID 10 m**, first ring at **3.5 m**, **pitch 20 m**  
+- Window-tube spans (10 m) between rings; 3.5 m service clearances at both ends  
+- Export: single **OBJ** file + **CSV** table (Table-1 equivalent)
+
+> Windows are *not* cut into the barrel in EV0 to keep meshing robust and fast.  
+> EV1+ will introduce aperture cutouts, frames, and glazing solids per program spec.
+
+## Usage
+
+```bash
+python -m simulations.sphere_space_station_simulations.evolutions.evo0_deck000
+```
+
+Artifacts:
+
+- `simulations/results/deck000_ev0/deck000_ev0.obj`  
+- `simulations/results/deck000_ev0/deck000_ev0_segments.csv`
+
+Import the OBJ in Blender/CAD and proceed with ring-level detailing.
+
+## Notes
+
+- Mesh is a double-skin tube (outer + inner surface), no end caps (for contiguous joining).
+- Radial tessellation default `96` (configurable in `Deck000Params.radial_segments`).
+- All distances in **meters**; z-axis points North→South (z=0 at North interior face).

--- a/simulations/sphere_space_station_simulations/scripts/deck000_evo0_export.py
+++ b/simulations/sphere_space_station_simulations/scripts/deck000_evo0_export.py
@@ -1,0 +1,18 @@
+"""
+Convenience runner to export EV0 artifacts without touching package internals.
+"""
+
+from pathlib import Path
+from simulations.sphere_space_station_simulations.evolutions.evo0_deck000 import (
+    build_and_export_ev0,
+)
+
+
+def main() -> None:
+    out = build_and_export_ev0(Path("simulations/results/deck000_ev0"))
+    for k, v in out.items():
+        print(f"{k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/simulations/sphere_space_station_simulations/scripts/readme.md
+++ b/simulations/sphere_space_station_simulations/scripts/readme.md
@@ -1,0 +1,5 @@
+# Scripts
+
+Utility entry points for the `sphere_space_station_simulations` package.
+
+- `deck000_evo0_export.py`: Exports the DECK000 EV0 geometry and segment table.

--- a/simulations/tests/test_deck000_evo0.py
+++ b/simulations/tests/test_deck000_evo0.py
@@ -1,0 +1,50 @@
+import math
+from simulations.sphere_space_station_simulations.evolutions.evo0_deck000 import (
+    Deck000Params,
+    generate_segments,
+)
+
+
+def nearly(a, b, tol=1e-9):
+    return abs(a - b) <= tol
+
+
+def test_segment_positions_match_spec_table_1():
+    p = Deck000Params()
+    segs = generate_segments(p)
+    # Expected first items:
+    exp = [
+        ("clearance_north", 0.0, 3.5),
+        ("ring_00", 3.5, 13.5),
+        ("window_00", 13.5, 23.5),
+        ("ring_01", 23.5, 33.5),
+        ("window_01", 33.5, 43.5),
+        ("ring_02", 43.5, 53.5),
+        ("window_02", 53.5, 63.5),
+        ("ring_03", 63.5, 73.5),
+        ("window_03", 73.5, 83.5),
+        ("ring_04", 83.5, 93.5),
+        ("window_04", 93.5, 103.5),
+        ("ring_05", 103.5, 113.5),
+        ("window_06", 113.5, 123.5),
+        ("clearance_south", 123.5, 127.0),
+    ]
+    names = [s["name"] for s in segs]
+    z0s = [s["z0"] for s in segs]
+    z1s = [s["z1"] for s in segs]
+    assert len(segs) == len(exp)
+    for i, (name, z0, z1) in enumerate(exp):
+        assert names[i] == name
+        assert nearly(z0s[i], z0)
+        assert nearly(z1s[i], z1)
+
+
+def test_radii_are_correct():
+    p = Deck000Params()
+    segs = generate_segments(p)
+    for s in segs:
+        if s["type"] == "ring":
+            assert math.isclose(s["r_inner"], p.ring_ri)
+        else:
+            assert math.isclose(s["r_inner"], p.barrel_ri)
+        assert math.isclose(s["r_outer"], p.barrel_ro)


### PR DESCRIPTION
## Summary
- add EV0 evolution module building DECK000 tube segments with OBJ and CSV export
- include convenience runner and tests for segment table
- document new evolution in engineering and software design guides

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/evolutions/__init__.py simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py simulations/sphere_space_station_simulations/scripts/deck000_evo0_export.py simulations/tests/test_deck000_evo0.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py simulations/sphere_space_station_simulations/evolutions/__init__.py simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py simulations/sphere_space_station_simulations/scripts/deck000_evo0_export.py simulations/tests/test_deck000_evo0.py`
- `PYTHONPATH=. pytest -q simulations/tests/test_deck000_evo0.py`

------
https://chatgpt.com/codex/tasks/task_e_6899fd628e3c832aad27e34a7c09c7cc