### PR TITLE
Clarify EVOL-00 deck wording and tag v0.1.0

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.11
+version: 1.3.12
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.12
+    date: 2025-08-16
+    change: "Clarified EVOL-00 deck module wording and tagged EVOL-00-DECK000-v0.1.0"
   - version: 1.3.11
     date: 2025-08-15
     change: "Introduced EV0 deck module for axial tube geometry"

--- a/simulations/sphere_space_station_simulations/evolutions/__init__.py
+++ b/simulations/sphere_space_station_simulations/evolutions/__init__.py
@@ -1,9 +1,10 @@
 """
 Evolutions namespace for Sphere Space Station geometry.
 
-EVOLUTION 0:
- - Minimal, CAD-freundliche Volumendarstellung der DECK000-Röhre
- - Ohne Boolesche Fenster-Ausschnitte (Fenster später in EV1)
+EVOL-00 (SemVer v0.1.0):
+- Minimal, CAD-freundliche Volumendarstellung der DECK000-Röhre
+- Fenster-Ausschnitte laut SSOT gehören zu EVOL‑00, sind hier jedoch
+  noch nicht modelliert (geplant für v0.1.1).
 """
 
 __all__ = [

--- a/simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py
+++ b/simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py
@@ -1,5 +1,9 @@
 """
-EVOLUTION 0 – DECK000 'Wormhole' baseline CAD geometry.
+EVOL-00 – DECK000 "Wormhole" baseline CAD geometry (SemVer v0.1.0).
+
+This initial version models the axial tube **without** window apertures to keep
+meshing robust.  According to the SSOT, EVOL‑00 includes rectangular window
+units between the docking rings; those cut-outs will follow in v0.1.1.
 
 Generates a segmented axial tube with:
  - Overall length: 127 m
@@ -8,9 +12,6 @@ Generates a segmented axial tube with:
  - Start of first ring at 3.5 m from the North pole interior face
  - Ring pitch 20 m; window-tube modules (10 m) between rings
  - 3.5 m service clearances at both ends
-
-EV0 deliberately keeps window cutouts as TODO (no boolean subtractions), focusing on
-structural barrels + rings to enable fast CAD import and downstream detailing (EV1+).
 
 Exports:
  - OBJ mesh (watertight shell segments per module)

--- a/simulations/sphere_space_station_simulations/evolutions/readme.md
+++ b/simulations/sphere_space_station_simulations/evolutions/readme.md
@@ -1,14 +1,15 @@
 # Evolutions – DECK000
 
-**EVOLUTION 0** implements the baseline axial tube geometry for **DECK000**:
+**EVOL-00 v0.1.0** implements the baseline axial tube geometry for **DECK000**
+without window cut-outs:
 
-- Length 127 m; barrel OD 22 m, ID 20 m  
-- Six docking rings (10 m each) with constricted **ID 10 m**, first ring at **3.5 m**, **pitch 20 m**  
-- Window-tube spans (10 m) between rings; 3.5 m service clearances at both ends  
+- Length 127 m; barrel OD 22 m, ID 20 m
+- Six docking rings (10 m each) with constricted **ID 10 m**, first ring at **3.5 m**, **pitch 20 m**
+- Window-tube spans (10 m) between rings; 3.5 m service clearances at both ends
 - Export: single **OBJ** file + **CSV** table (Table-1 equivalent)
 
-> Windows are *not* cut into the barrel in EV0 to keep meshing robust and fast.  
-> EV1+ will introduce aperture cutouts, frames, and glazing solids per program spec.
+Per SSOT, EVOL‑00 includes rectangular window units between the docking rings.
+These apertures will be added in **v0.1.1**.
 
 ## Usage
 


### PR DESCRIPTION
### Summary
- align EVOL-00 DECK000 wording with SSOT; note that v0.1.0 omits window apertures
- update evolution README and package docs accordingly
- record change in software design decisions and create tag `EVOL-00-DECK000-v0.1.0`

### Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a03fa7ae0832ab57e5830dd68e5bf