### PR TITLE
Fix invalid EVOL link in documentation summary

### DIFF
--- a/documents/summary.md
+++ b/documents/summary.md
@@ -43,7 +43,7 @@
       * [7.6.1.1 Guideline Document: Evolution‑Engineering-Naming-Folder Convention](07-comprehensive-technical-documentation/7.6-engineering/7.6.1-global-standards/7.6.1.1-guideline-document-engineering-naming---folder-convention.md)
       * [7.6.1.2 Guideline Document: The Evolution Principle](07-comprehensive-technical-documentation/7.6-engineering/7.6.1-global-standards/7.6.1.2-guideline-document-the-evolution-principle.md)
     * [7.6.2-evolutions](07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/readme.md)
-      * [Current Evolution: (EVOLUTION 00 - The Beginning)(EVOL-00\readme.md)](07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/current-evolution.md)
+      * [Current Evolution: EVOLUTION 00 – The Beginning](07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/current-evolution.md)
       * [EVOLUTION 00 — The Beginning](07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/readme.md)
         * [SPEC-00-STR-DECKS-DECK000-0001-wormhole-docking-tunnel-EN-v0.1.0-DRAFT](07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/spec-00-str-decks-deck000-0001-wormhole-docking-tunnel-en-v0.1.0-draft.md.md)
     * [7.6.3 History](07-comprehensive-technical-documentation/7.6-engineering/7.6.3-history/readme.md)


### PR DESCRIPTION
## Summary
- correct malformed EVOLUTION 00 link in `documents/summary.md`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a447dca68832a98b397aed03b1eac