### PR TITLE
Add glTF export and material support to deck evolution

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/02-engineering/02-concepts/construction-handbook.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/02-engineering/02-concepts/construction-handbook.md
@@ -1,9 +1,12 @@
 ---
 title: "Construction Handbook"
-version: 1.1.2
+version: 1.1.3
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.1.3
+    date: 2025-08-18
+    change: "EV0 deck now exports glTF with materials; CadQuery usage under review"
   - version: 1.1.2
     date: 2025-08-15
     change: "Documented DECK000 EV0 geometry export"
@@ -34,6 +37,7 @@ This handbook collects key decisions for modeling the Sphere Space Station and s
 - **Blender helpers** reside in the subpackage `blender_helpers` and are imported by the adapter.
 - **Hull geometry** is computed by `geometry/hull.py` and imported by the deck logic.
 - **Deck evolution modules**: EV0 adds baseline DECK000 tube segments with OBJ+CSV export.
+- **EV0 enhancements**: Material support added to segments and glTF export complements OBJ+CSV outputs. CadQuery remains optional pending dependency trade-offs.
 - **Deck supports and docking ports** can be parametrized in `SphereDeckCalculator`,
   enriching the structural model with columns and equatorial docking locations.
 - **Station simulation** has moved to `simulation.py` and can be started directly from the library. `run_simulation.py` is now called `starter.py`.

--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.13
+version: 1.3.14
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.14
+    date: 2025-08-18
+    change: "EV0 deck evolution exports glTF with materials; CadQuery integration reviewed"
   - version: 1.3.13
     date: 2025-08-17
     change: "Unified Blender scene preparation into shared module"
@@ -108,4 +111,5 @@ Preamble and international safety standards.
 
 ## 1.7 Deck evolution modules
 
-- EV0 module generates DECK000 axial tube geometry and exports OBJ and CSV reports.
+- EV0 module generates DECK000 axial tube geometry and exports OBJ, CSV and glTF reports with basic materials.
+- CadQuery would allow fully parametric solids but remains optional due to its heavy dependency footprint.

--- a/simulations/sphere_space_station_simulations/evolutions/readme.md
+++ b/simulations/sphere_space_station_simulations/evolutions/readme.md
@@ -1,12 +1,12 @@
 # Evolutions – DECK000
 
-**EVOL-00 v0.1.0** implements the baseline axial tube geometry for **DECK000**
+**EVOL-00 v0.1.1** implements the baseline axial tube geometry for **DECK000**
 without window cut-outs:
 
 - Length 127 m; barrel OD 22 m, ID 20 m
 - Six docking rings (10 m each) with constricted **ID 10 m**, first ring at **3.5 m**, **pitch 20 m**
 - Window-tube spans (10 m) between rings; 3.5 m service clearances at both ends
-- Export: single **OBJ** file + **CSV** table (Table-1 equivalent)
+- Export: **OBJ**, **CSV** table (Table-1 equivalent) and **glTF** with basic materials
 
 Per SSOT, EVOL‑00 includes rectangular window units between the docking rings.
 These apertures will be added in **v0.1.1**.
@@ -19,10 +19,11 @@ python -m simulations.sphere_space_station_simulations.evolutions.evo0_deck000
 
 Artifacts:
 
-- `simulations/results/deck000_ev0/deck000_ev0.obj`  
+- `simulations/results/deck000_ev0/deck000_ev0.obj`
 - `simulations/results/deck000_ev0/deck000_ev0_segments.csv`
+- `simulations/results/deck000_ev0/deck000_ev0.glb`
 
-Import the OBJ in Blender/CAD and proceed with ring-level detailing.
+Import the OBJ or glTF in Blender/CAD and proceed with ring-level detailing.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add material fields to EV0 deck parameters and segment CSV
- implement glTF export alongside existing OBJ/CSV outputs
- document evaluation of optional CadQuery usage

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `PYTHONPATH=. pytest simulations/tests/test_deck000_evo0.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689f4f2caec8832a8bdbb7750e3c8920