### PR TITLE
Add Evolution 00 Blender simulator and results directory

### DIFF
--- a/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
+++ b/project/sphere-space-station-earth-one/01-project-planning/08-simulations/software-design-decisions.md
@@ -1,9 +1,12 @@
 ---
 title: "Software Design Decisions"
-version: 1.3.14
+version: 1.3.15
 owner: "Robert Alexander Massinger"
 license: "(c) COPYRIGHT 2023 - 2025 by Robert Alexander Massinger, Munich, Germany. ALL RIGHTS RESERVED."
 history:
+  - version: 1.3.15
+    date: 2025-08-19
+    change: "Added Evolution 00 Blender simulator and consolidated results directory"
   - version: 1.3.14
     date: 2025-08-18
     change: "EV0 deck evolution exports glTF with materials; CadQuery integration reviewed"

--- a/simulations/blender_evo0_simulator/adapter.py
+++ b/simulations/blender_evo0_simulator/adapter.py
@@ -1,0 +1,56 @@
+"""Blender adapter importing Evolution 00 GLB files as separate collections."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+try:  # pragma: no cover - Blender required
+    import bpy  # type: ignore
+except Exception:  # pragma: no cover - Blender not available
+    bpy = None  # type: ignore[assignment]
+
+
+def import_glb(path: Path) -> None:
+    """Import a single GLB/GLTF file into Blender."""
+    if bpy is None:  # pragma: no cover - Blender required
+        raise ModuleNotFoundError("bpy module is required")
+    bpy.ops.import_scene.gltf(filepath=str(path), import_scene_as_collection=True)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Import Evolution 00 GLB files")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help="GLB files or directories containing them; defaults to results/evolutions/evolution-00",
+    )
+    args = parser.parse_args(argv)
+
+    if bpy is None:  # pragma: no cover - Blender required
+        raise ModuleNotFoundError("bpy module is required")
+
+    to_import: list[Path] = []
+    if args.paths:
+        for p in args.paths:
+            path = Path(p)
+            if path.is_dir():
+                to_import.extend(sorted(path.glob("*.glb")))
+            else:
+                to_import.append(path)
+    else:
+        default_dir = (
+            Path(__file__).resolve().parent
+            / ".."
+            / "results"
+            / "evolutions"
+            / "evolution-00"
+        )
+        to_import.extend(sorted(default_dir.glob("*.glb")))
+
+    for glb in to_import:
+        import_glb(glb)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()

--- a/simulations/blender_evo0_simulator/readme.md
+++ b/simulations/blender_evo0_simulator/readme.md
@@ -1,0 +1,2 @@
+# 1. Blender Evolution 00 Simulator
+Imports glTF files for Evolution 00 into Blender. The adapter loads all `.glb` files from `simulations/results/evolutions/evolution-00` or from paths passed on the command line.

--- a/simulations/blender_evo0_simulator/starter.py
+++ b/simulations/blender_evo0_simulator/starter.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Launch Blender for Evolution 00")
+    parser.add_argument(
+        "--blender",
+        default=os.getenv("BLENDER_PATH"),
+        help="Path to the Blender executable (or set BLENDER_PATH)",
+    )
+    parser.add_argument(
+        "--script",
+        default=os.path.join(os.path.dirname(__file__), "adapter.py"),
+        help="Blender Python file to execute",
+    )
+    parser.add_argument(
+        "--background", action="store_true", help="Run Blender in background mode"
+    )
+    parser.add_argument(
+        "extra",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to Blender and the adapter",
+    )
+
+    args = parser.parse_args()
+
+    blender = args.blender
+    if not blender:
+        print("BLENDER_PATH not set and --blender not provided", file=sys.stderr)
+        sys.exit(1)
+
+    cmd = [blender]
+    if args.background:
+        cmd.append("--background")
+    cmd += ["--python", args.script]
+    if args.extra:
+        cmd += args.extra
+
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/simulations/readme.md
+++ b/simulations/readme.md
@@ -6,6 +6,7 @@ The `deck_calculator` subdirectory exposes `deck_calculations_script.py` as a li
 
 `blender_deck_simulator` and `blender_hull_simulation` provide example Blender scripts for visualising the decks and the outer hull respectively.
 
+`blender_evo0_simulator` imports Evolution 00 glTF collections.
 Simulation code is provided under the MIT license for educational purposes. Refer to `LICENSE-MIT` for details. Other content within this repository may be subject to the proprietary license described in the root `README.md`.
 
 ---
@@ -15,5 +16,7 @@ Dieser Ordner enthält Beispielskripte und Daten zur Erzeugung von Visualisierun
 Im Unterordner `deck_calculator` steht `deck_calculations_script.py` als schlanke Hülle zur wiederverwendbaren Bibliothek bereit.
 
 Die Verzeichnisse `blender_deck_simulator` und `blender_hull_simulation` beinhalten Blender-Skripte, welche die Decks bzw. die Außenhülle visualisieren.
+
+Das Verzeichnis `blender_evo0_simulator` importiert glTF-Sammlungen der Evolution 00.
 
 Der Quellcode der Simulationen steht zu Lernzwecken unter der MIT-Lizenz. Weitere Inhalte können proprietären Lizenzbedingungen unterliegen, siehe `README.md` im Hauptverzeichnis.

--- a/simulations/results/evolutions/evolution-00/readme.md
+++ b/simulations/results/evolutions/evolution-00/readme.md
@@ -1,0 +1,2 @@
+# 1. Evolution 00 Results
+Generated geometry and reports for Evolution 00 of the Sphere Space Station Earth ONE.

--- a/simulations/results/evolutions/readme.md
+++ b/simulations/results/evolutions/readme.md
@@ -1,0 +1,2 @@
+# 1. Evolution Results
+Collections of output artifacts grouped by evolution stage.

--- a/simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py
+++ b/simulations/sphere_space_station_simulations/evolutions/evo0_deck000.py
@@ -456,7 +456,7 @@ def export_gltf(meshes: List[Mesh], out_path: Path) -> None:
 
 
 def build_and_export_ev0(
-    out_dir: Path | str = "simulations/results/deck000_evo0",
+    out_dir: Path | str = "simulations/results/evolutions/evolution-00",
 ) -> Dict[str, Path]:
     """
     Generates EV0 geometry & reports into out_dir.


### PR DESCRIPTION
## Summary
- add `blender_evo0_simulator` with adapter and starter to load Evolution 00 GLB collections in Blender
- export Evolution 00 geometry to `simulations/results/evolutions/evolution-00`
- document Evolution 00 simulator in design notes and READMEs

## Testing
- `python -m py_compile simulations/deck_calculator/deck_calculations_script.py`
- `black --check simulations/deck_calculator/deck_calculations_script.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5e08cee4832aa09d11c52de512c8