### PR TITLE
[SPEC][STR][DECKS][EVOL-00] add front matter and language harmonization

### DIFF
--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-013-sector-layout-and-interfaces-en-de-v0.1.0.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-013-sector-layout-and-interfaces-en-de-v0.1.0.md
@@ -1,3 +1,26 @@
+---
+id: spec-00-str-decks-013-0001
+title: DECK 013 sector layout and interfaces
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: DECKS
+system_id: "013"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-16
+lang: en-de
+---
 # SPEC-00-STR-DECKS-013-sector-layout-and-interfaces-EN-DE-v0.1.0
 
 **Project:** Sphere Space Station – Earth ONE (Ø 127.00 m)  

--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-014-sector-layout-and-interfaces-en-de-v0.1.0.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-014-sector-layout-and-interfaces-en-de-v0.1.0.md
@@ -1,3 +1,26 @@
+---
+id: spec-00-str-decks-014-0001
+title: DECK 014 sector layout and interfaces
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: DECKS
+system_id: "014"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-16
+lang: en-de
+---
 # SPEC-00-STR-DECKS-014-sector-layout-and-interfaces-EN-DE-v0.1.0
 
 **Project:** Sphere Space Station – Earth ONE (Ø 127.00 m)  

--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-015-sector-layout-and-interfaces-en-de-v0.1.0.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-015-sector-layout-and-interfaces-en-de-v0.1.0.md
@@ -1,3 +1,26 @@
+---
+id: spec-00-str-decks-015-0001
+title: DECK 015 sector layout and interfaces
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: DECKS
+system_id: "015"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-16
+lang: en-de
+---
 # SPEC-00-STR-DECKS-015-sector-layout-and-interfaces-EN-DE-v0.1.0
 
 **Project:** Sphere Space Station – Earth ONE (Ø 127.00 m)  

--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-deck000-0001-wormhole-docking-tunnel-en-de-v0.1.0-draft.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-deck000-0001-wormhole-docking-tunnel-en-de-v0.1.0-draft.md
@@ -1,21 +1,52 @@
-### SPEC-00-STR-DECKS-DECK000-0001-wormhole-docking-tunnel-EN-v0.1.0-DRAFT 
+---
+id: spec-00-str-decks-deck000-0001
+title: DECK000 wormhole docking tunnel
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: DECKS
+system_id: "DECK000"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-10
+lang: en-de
+---
+# SPEC-00-STR-DECKS-DECK000-0001-wormhole-docking-tunnel-EN-DE-v0.1.0-DRAFT
 
 **The Engineering of DECK000 – The Wormhole**
 
-**Document status:** Draft (Evolution 1 – Baseline)
+**Document status:** Draft (EVOL-00 baseline)
 **Date:** 2025‑08‑10
 **Applies to:** Earth ONE class sphere station (Ø 127 m)
+
+---
+
+## Summary / Kurzfassung (EN/DE)
+
+**EN:** DECK000 is the axial, pressurized docking and transit tube spanning the North–South poles. The EVOL-00 baseline defines a 127 m long SiC-composite barrel with six Inconel docking rings and window segments for observation and transfer in micro‑g.
+
+**DE:** DECK000 ist der axiale, druckbeaufschlagte Docking- und Transittunnel zwischen Nord- und Südpol. Die EVOL‑00-Basis umfasst einen 127 m langen SiC-Verbundzylinder mit sechs Inconel-Docking-Ringen und Fenstersegmenten für Beobachtung und Transfer im Mikro-g.
 
 ---
 
 #### 1 Abstract
 
 
-DECK000 (“The Wormhole”) is the axial, pressurized docking and transit tube that runs straight through the station from the North pole to the South pole. In Evolution 1, the assembly is a 127 m long tube with an outer diameter of 22 m and a clear inner diameter of 20 m. The primary barrel is a silicon‑carbide (SiC) composite reinforced with steel or Inconel for toughness. Starting 3.5 m from the north polar end and repeating every 20 m along the axis, 10 m‑long Inconel docking‑ring subassemblies are installed and numbered sequentially (00, 01, 02 …) from North to South. Between docking rings, “window tube” segments provide outward viewing; each segment integrates rectangular window units of 4 m (axial) × 3 m (tall), built to the program’s space‑grade multilayer window specification (ALON/sapphire + fused silica + polycarbonate + borosilicate/cerium‑doped glass). The result is a micro‑g corridor (near the spin axis) enabling safe berthing, people/cargo transfer, observation, and emergency egress.
+DECK000 (“The Wormhole”) is the axial, pressurized docking and transit tube that runs straight through the station from the North pole to the South pole. In EVOL‑00, the assembly is a 127 m long tube with an outer diameter of 22 m and a clear inner diameter of 20 m. The primary barrel is a silicon‑carbide (SiC) composite reinforced with steel or Inconel for toughness. Starting 3.5 m from the north polar end and repeating every 20 m along the axis, 10 m‑long Inconel docking‑ring subassemblies are installed and numbered sequentially (00, 01, 02 …) from North to South. Between docking rings, “window tube” segments provide outward viewing; each segment integrates rectangular window units of 4 m (axial) × 3 m (tall), built to the program’s space‑grade multilayer window specification (ALON/sapphire + fused silica + polycarbonate + borosilicate/cerium‑doped glass). The result is a micro‑g corridor (near the spin axis) enabling safe berthing, people/cargo transfer, observation, and emergency egress.
 
 ---
 
-#### 2 Description (Evolution 1 – Baseline Geometry & Materials)
+#### 2 Description (EVOL‑00 – Baseline Geometry & Materials)
 
 ##### A. System Overview
 
@@ -29,7 +60,7 @@ DECK000 (“The Wormhole”) is the axial, pressurized docking and transit tube 
 
 * **Ring modules:** 10 m axial length; OD 22 m (flush with main barrel OD); ID 10 m (constricted throat for docking hardware and hatchway integration).
 * **Material:** Inconel (high‑temperature and corrosion resistance; excellent toughness).
-* **Placement & numbering:** Starting **3.5 m** from the North pole interior face and repeating at a **20 m pitch**; numbered **00** (northmost) through **05** (southmost) in Evolution 1.
+* **Placement & numbering:** Starting **3.5 m** from the North pole interior face and repeating at a **20 m pitch**; numbered **00** (northmost) through **05** (southmost) in EVOL‑00.
 
 **Table 1 — Ring and window‑segment positions (from North pole interior face)**
 
@@ -50,7 +81,7 @@ DECK000 (“The Wormhole”) is the axial, pressurized docking and transit tube 
 |       — | Window tube  |           113.5 |         123.5 |             10.0 |                                     |
 |       — | Clearance    |           123.5 |         127.0 |              3.5 | aft clearance / taper / systems     |
 
-> **Note:** Evolution 1 uses six docking rings (00–05), preserving 3.5 m service clearances at both ends. Later evolutions may revise counts, spacing, or diameters based on interface selections and docking traffic models.
+> **Note:** EVOL‑00 uses six docking rings (00–05), preserving 3.5 m service clearances at both ends. Later evolutions may revise counts, spacing, or diameters based on interface selections and docking traffic models.
 
 ##### C. Window Segments & Glazing Units
 

--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-deck001-0001-transfer-node-and-radial-systems-en-de-v0.1.0-draft.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-decks-deck001-0001-transfer-node-and-radial-systems-en-de-v0.1.0-draft.md
@@ -1,33 +1,66 @@
-# SPEC-00-STR-DECKS-DECK001-0001-transfer-node-and-radial-systems-EN-v0.1.0-DRAFT
+---
+id: spec-00-str-decks-deck001-0001
+title: DECK001 transfer node and radial systems
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: DECKS
+system_id: "DECK001"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-16
+lang: en-de
+---
+# SPEC-00-STR-DECKS-DECK001-0001-transfer-node-and-radial-systems-EN-DE-v0.1.0-DRAFT
 
-**The Engineering of DECK001 – Reception, Transfer & Radial Systems**
-**Document status:** Draft (Evolution 1 – Baseline)
-**Date:** 2025-08-16
+**The Engineering of DECK001 – Reception, Transfer & Radial Systems**  
+**Document status:** Draft (EVOL-00 baseline)  
+**Date:** 2025-08-16  
 **Applies to:** Earth ONE class sphere station (Ø 127 m)
 
 ---
 
-## 1. Abstract
+## 1. Abstract / Zusammenfassung (EN/DE)
 
-DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen DECK 000 („Wormhole“) und bildet die **Haupt-Empfangsebene** für ankommende Personen und Fracht. Er integriert **radiale Druck-/Brandschotts**, **Radialtransport** (Heavy-Lift- & Personenaufzüge, Servicetunnel), **tangentiale und polwärts gerichtete Bahnen & Wege** sowie **Empfangs- und Transfer-Airlocks** von den Docking-Ringen in DECK 000 zu DECK 001 und weiter zu den Außen-Decks. Geometrisch liegt DECK 001 zwischen **rᵢ = 10.5 m** und **rₒ,net = 13.5 m** bei **Deckhöhe = 3.0 m**; die nominelle Zentrifugalbeschleunigung am Nettradius beträgt **3.38 m/s² (\~0.34 g)**.
+**EN:** DECK 001 is the first pressurized distribution ring outside the axial DECK000 (“Wormhole”) and acts as the main reception level for incoming crew and cargo. It integrates radial pressure/fire bulkheads, radial transport (heavy-lift & passenger elevators, service tunnels), tangential and polar corridors, and reception/transfer airlocks linking the docking rings in DECK000 to DECK001 and onward to the outer decks. Geometrically it spans **rᵢ = 10.5 m** to **rₒ,net = 13.5 m** with **deck height = 3.0 m**; nominal centrifugal acceleration at the net radius is **3.38 m/s² (~0.34 g)**.
+
+**DE:** DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen DECK 000 („Wormhole“) und bildet die **Haupt-Empfangsebene** für ankommende Personen und Fracht. Er integriert **radiale Druck-/Brandschotts**, **Radialtransport** (Heavy-Lift- & Personenaufzüge, Servicetunnel), **tangentiale und polwärts gerichtete Bahnen & Wege** sowie **Empfangs- und Transfer-Airlocks** von den Docking-Ringen in DECK 000 zu DECK 001 und weiter zu den Außen-Decks. Geometrisch liegt DECK 001 zwischen **rᵢ = 10.5 m** und **rₒ,net = 13.5 m** bei **Deckhöhe = 3.0 m**; die nominelle Zentrifugalbeschleunigung am Nettradius beträgt **3.38 m/s² (\~0.34 g)**.
 
 ---
 
-## 2. Baseline Geometry & Environment (EVOL-01)
+## 2. Baseline Geometry & Environment (EVOL-00)
 
-* **Radial band:** inner radius **10.5 m**, net outer radius **13.5 m**, height **3.0 m**.
-  **Tangential length:** \~**124.24 m** (inner) bis **123.07 m** (outer).
-* **Gravity:** \~**3.38 m/s²** at net radius (EVOL-01 spin law).
+* **Radial band:** inner radius **10.5 m**, net outer radius **13.5 m**, height **3.0 m**.  
+  **Tangential length:** ~**124.24 m** (inner) to **123.07 m** (outer).
+* **Gravity:** ~**3.38 m/s²** at net radius (EVOL-00 spin law).
 * **Deck role:** Mid-gravity deck for **residential/operational** uses; serves as **primary reception & distribution hub** from the axial wormhole to outer decks.
 
 ---
 
 ## 3. Functions & Scope
 
-1. **Reception & Transfer:** sichere Aufnahme/Verteilung von Crew, Passagieren und Fracht aus DECK 000 (Docking-Ringe) in die Ring-Topologie, inkl. Quarantäne- und Sicherheits-Checks.
-2. **Radial Core Access:** Aufzüge (Heavy-Lift & Personen) und Servicetunnel verbinden **alle Decks** vom Core zu den Außenlagen.
-3. **Tangential & Polar Mobility:** umlaufende Wege/Bahnen + polwärts gerichtete (meridionale) Zubringer zu den polnahen Knoten (Schnittstellen zu DECK 000).
-4. **Safety Envelope:** segmentierte **Druck-/Brandschott-Geometrie**, Drucktüren, Airlocks, inert-Gas-Brandunterdrückung.
+1. **Reception & Transfer / Empfang & Verteilung**
+   - **EN:** Secure intake and distribution of crew, passengers, and cargo from DECK000 (docking rings) into the ring topology, including quarantine and safety checks.
+   - **DE:** Sichere Aufnahme/Verteilung von Crew, Passagieren und Fracht aus DECK 000 (Docking-Ringe) in die Ring-Topologie, inkl. Quarantäne- und Sicherheits-Checks.
+2. **Radial Core Access / Radialer Kernzugang**
+   - **EN:** Heavy-lift and passenger elevators plus service tunnels connect **all decks** from the core to the outer bands.
+   - **DE:** Aufzüge (Heavy-Lift & Personen) und Servicetunnel verbinden **alle Decks** vom Core zu den Außenlagen.
+3. **Tangential & Polar Mobility / Tangentiale & polare Mobilität**
+   - **EN:** Circumferential paths and polar (meridional) spurs route traffic to near-pole nodes (interfaces to DECK000).
+   - **DE:** Umlaufende Wege/Bahnen + polwärts gerichtete (meridionale) Zubringer zu den polnahen Knoten (Schnittstellen zu DECK 000).
+4. **Safety Envelope / Sicherheitsrahmen**
+   - **EN:** Segmented pressure/fire bulkheads, pressure doors, airlocks, and inert-gas fire suppression.
+   - **DE:** Segmentierte **Druck-/Brandschott-Geometrie**, Drucktüren, Airlocks, inert-Gas-Brandunterdrückung.
 
 ---
 
@@ -43,8 +76,7 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 ### B) Radialer Transport – Heavy-Lift & Passenger Elevators
 
 * **Mandat:** durchgehende Verbindung **DECK 000 ⇄ 015** (Personen & Fracht); redundante Pfade.
-* **Layout (EVOL-01):**
-
+* **Layout (EVOL-00):**
   * **4 Heavy-Lift-Schächte** (90°-Versatz), freie Lichtfläche ≥ 4.0 m × 3.0 m, **50 kN Nutzlast**, Dock-/Paletten-Kompatibilität.
   * **8 Personenaufzüge** (alle 45°, um 22.5° gegenüber Heavy-Lift versetzt), Kabinen 1.6 m × 1.6 m, 10–12 Pax.
   * **Stationsnorm-Interface** (mechanisch/elektrisch/Datentechnik) identisch über alle Decks; **Not-Handläufe** & **Leiterläufe** im Schacht.
@@ -53,24 +85,23 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 ### C) Radiale Servicetunnel (Utilities Spine, beginnend auf DECK 001)
 
 * **Zweck:** Trassen für **Luft/CO₂-Rücklauf, Wasser/Kondensat, Energie-DC-Busse, Daten/Comms**, Wärme-Sekundärkreise.
-* **Querschnitt:** typ. ≥ 1.2 m-Gangbreite; **doppelte Trunkings** (getrennte rote/gelbe Utility-Seite) für Instandhaltung im laufenden Betrieb.
+* **Querschnitt:** typ. ≥ 1.2 m Gangbreite; **doppelte Trunkings** (getrennte rote/gelbe Utility-Seite) für Instandhaltung im laufenden Betrieb.
 * **Druck-/Brand-Zonen:** **Abschluss-Türen** pro Sektor; **Schnell-Isolierungs-Klappen** in Lüftung.
 
 ### D) Tangentiale Bahnen & Wege (on-Deck Mobility)
 
-* **Gehwege:** 2 × umlaufende **3.0 m-Korridore** (inner/outer ring), Farbleitsystem & Photometrie gemäß Stationsstandard.
-* **Fördertechnik:** **Conveyors/Schienenträger** für Material-Fluss, **kleine Rangier-Rail-Vehikel** in EVOL-01 (Handbetrieb/halbautonom).
+* **Gehwege:** 2 × umlaufende **3.0 m Korridore** (inner/outer ring), Farbleitsystem & Photometrie gemäß Stationsstandard.
+* **Fördertechnik:** **Conveyors/Schienenträger** für Material-Fluss, **kleine Rangier-Rail-Vehikel** in EVOL-00 (Handbetrieb/halbautonom).
 
 ### E) Polwärts gerichtete Zubringer (Meridional Spurs)
 
-* **Definition:** kurze **meridionale Trassen** je Quadrant, die von DECK 001 **richtung Pol** in **Wurmlöcher-Knoten** (Docking-Ring-Ebenen in DECK 000) führen.
+* **Definition:** kurze **meridionale Trassen** je Quadrant, die von DECK 001 **Richtung Pol** in **Wurmlöcher-Knoten** (Docking-Ring-Ebenen in DECK 000) führen.
 * **Zweck:** schnelles **Crew-/Fracht-Umsetzen** zwischen Ring-Verkehr und axialem Docking-Korridor; Notausweichrouten.
-* **Schnittstellen:** **air-tight Transfer-Hatches** zu **DECK 000 Docking-Rings 01–04** (EVOL-01 baseline), inklusive **Druck-Isolationspunkte** an Ring-Grenzen (Rings können als Kompartiment versiegelt werden).
+* **Schnittstellen:** **air-tight Transfer-Hatches** zu **DECK 000 Docking-Rings 01–04** (EVOL-00 baseline), inklusive **Druck-Isolationspunkte** an Ring-Grenzen (Rings können als Kompartiment versiegelt werden).
 
 ### F) Empfangs- & Durchschleuseanlagen (DECK 000 → DECK 001 → Outer Decks)
 
 * **Reception Vestibules (RV-Nodes):** vier **Empfangs-Knoten** (je Quadrant), direkt an die meridionalen Zubringer gekoppelt.
-
   * **Funktionen:** Einreise-/Sicherheits-Check, **medizinischer Quick-Screen**, **Baggage-Staging**, **Route-Guidance**.
   * **Schleusenlogik:** **Doppelschleusen** mit **autom. Druckangleich**, **Blast-Shutters** & **MMOD-Shades** nach Fenster-/Öffnungs-Norm.
 * **Weiterleitung:** kurze Wege zu **Passenger-Lobbies** (Personenaufzüge) und **Cargo-Bays** (Heavy-Lift).
@@ -79,7 +110,6 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 ### G) Drucktüren, Airlocks & Schutzsysteme
 
 * **Türklassen:**
-
   * **PT-A (Pressure-Tight, primary):** Haupt-Drucktüren der Sektorschotts (manuell + motorisch, Interlock).
   * **PT-B:** Türen in Servicetunneln, Aufzugsvorlauf, Technikräumen.
   * **AL-C (Airlock):** Personen-/Fracht-Schleusen mit zweifach redundanter Sensorsuite (Δp, O₂, Rauch, Temp).
@@ -87,7 +117,7 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 
 ### H) Polar Outer Hull (Deck 001 Band)
 
-* **Außenhülle (polnah, Deck-001-Band):** **\~0.5 m** dicke mehrlagige Composit-Hülle als Basis-Thermal-/Strahlungsschutz mit Anbindung an polare Struktur-Ringe; lokale **Durchdringungen** (Meridional-Spurs, Sensorik) mit metallischen C-Seals.
+* **Außenhülle (polnah, Deck-001-Band):** **~0.5 m** dicke mehrlagige Composit-Hülle als Basis-Thermal-/Strahlungsschutz mit Anbindung an polare Struktur-Ringe; lokale **Durchdringungen** (Meridional-Spurs, Sensorik) mit metallischen C-Seals.
 * **Materialsysteme:** SiC-Verbund, Polyimid-/Siloxan-Elastomere, Silica-Aerogel-Isolationslagen; Auswahl nach **LEO-Fenster/Glazing-Spec** für optische Öffnungen.
 
 ---
@@ -95,7 +125,7 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 ## 5. Interfaces
 
 * **To DECK 000 (Wormhole):** Anschluss an **Docking-Ring-Ebenen** via **meridionale Zubringer** + **Reception Vestibules**; **Druck-Isolationspunkte** an Ring-Grenzen (ring-as-compartment).
-* **To Outer Decks (002…):** **Radial-Aufzüge** (Heavy-Lift & Personen) + **Servicetunnel** setzen Vertikal-Kontinuität; Norm-Interface für Mechanik/Power/Comms ident. über alle Decks.
+* **To Outer Decks (002…):** **Radial-Aufzüge** (Heavy-Lift & Personen) + **Servicetunnel** setzen Vertikal-Kontinuität; Norm-Interface für Mechanik/Power/Comms identisch über alle Decks.
 * **To Station Systems:** Luft/CO₂-Rücklauf, Wasser/Kondensat, **Dual-DC-Bus** + lokale **UPS** für safety-kritische Aktoren, Comms-Rail.
 
 ---
@@ -116,7 +146,7 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 
 ---
 
-## 8. Verification & Acceptance (V\&V)
+## 8. Verification & Acceptance (V&V)
 
 * **Drucktests:** sektorweise Proof- & Leak-Tests (AL-C Schleusen, PT-A/-B Türen).
 * **Brand-Szenarien:** Inertgas-Auslösung, Evakuierungs-Drills, Tür-Interlock-Failover.
@@ -141,5 +171,3 @@ DECK 001 ist der **erste druckbeaufschlagte Verteilring** außerhalb des axialen
 * **Safety & materials:** inert-gas protocols, hull thickness, materials & window spec.
 
 ---
-
-

--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-geom-grav-0001-global-geometry-and-gravitation-en-de-v0.1.0-draft.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-geom-grav-0001-global-geometry-and-gravitation-en-de-v0.1.0-draft.md
@@ -1,6 +1,35 @@
+---
+id: spec-00-str-geom-grav-0001
+title: Global geometry and gravitation
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: GEOM-GRAV
+system_id: "0001"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-16
+lang: en-de
+---
 # SPEC-00-STR-GEOM-GRAV-0001 – Global Geometry & Gravitation *(EVOL-00, 127 m)*
 
-**Status:** DRAFT **Version:** v0.1.0 **Datum:** 2025-08-16
+## Summary / Kurzfassung (EN/DE)
+
+**EN:** Defines the overall geometry, hull layering and spin-derived gravity profile for Sphere Space Station **Earth ONE** (outer diameter **127 m**). Includes deck banding, comfort models and g-tables based on the EVOL-00 spin law (1 g at **r = 38 m**).
+
+**DE:** Definiert Geometrie, Hüllenaufbau und spin-basierte Gravitation für die Sphere Space Station **Earth ONE** (Außendurchmesser **127 m**). Enthält Deck-Bänder, Komfortmodelle und g-Tabellen gemäß EVOL-00 Spin-Law (1 g bei **r = 38 m**).
+
+**Status:** DRAFT **Version:** v0.1.0 **Date:** 2025-08-16
 **Scope:** Geometrie der Sphere Space Station **Earth ONE** (Außendurchmesser **127,00 m**), Hüllenaufbau (**0,50 m**), Deck-Bänder, künstliche Gravitation $a(r)=\omega^2 r$, Komfort-/Wohlfühlmodelle (grav-basiert + umweltbasiert), Tabellen mit aktuellen Werten je Deck inkl. Verweilzeit-Kategorien.
 **Spin-Kalibrierung (EVOL-00):** **1 g** $(g_0=9{,}80665\,\mathrm{m/s^2})$ bei **r = 38{,}00 m** ⇒ $\omega=\sqrt{g_0/38{,}00}=0{,}50801\,\mathrm{s^{-1}}$ ⇒ **4,852 rpm**.
 

--- a/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-sys-axial-radial-trade-0001-variant-study-longitude-vs-latitude-bulkheads-en-de-v0.1.0-draft.md
+++ b/documents/07-comprehensive-technical-documentation/7.6-engineering/7.6.2-evolutions/evol-00/02-specs/spec-00-str-sys-axial-radial-trade-0001-variant-study-longitude-vs-latitude-bulkheads-en-de-v0.1.0-draft.md
@@ -1,4 +1,33 @@
+---
+id: spec-00-str-sys-axial-radial-trade-0001
+title: Variant study longitude vs latitude bulkheads
+version: 0.1.0
+state: draft
+evolution: EVOL-00
+discipline: STR
+system: SYS-AXIAL-RADIAL-TRADE
+system_id: "0001"
+seq: "0001"
+owner: "@sgi-lina"
+reviewers:
+  - "@eng-elias"
+  - "@eng-leo"
+source_of_truth: false
+supersedes: []
+superseded_by: []
+rfc_links: []
+adr_links: []
+cr_links: []
+date: 2025-08-16
+lang: en-de
+---
 # SPEC-00-STR-SYS-AXIAL-RADIAL-TRADE-0001 — Variantenuntersuchung Längs-/Breitengrad-Schotten *(EVOL-00, 127 m)*
+
+## Summary / Kurzfassung (EN/DE)
+
+**EN:** Compares three structural and safety layouts for the sphere: **A) Longitudinal sectors**, **B) Latitudinal diaphragms ("LAT")**, **C) Combination**. Evaluates structural dynamics, pressure/fire/hazard containment, operations & maintenance, routing complexity, mass/manufacturing, and expandability. Result: **Option C** offers the best performance; recommended as baseline (EVOL-00 with 12 sector bulkheads A–L plus 3 LAT discs S40/EQ/N40, expanding to 7 LAT in EVOL-01).
+
+**DE:** Vergleich dreier Struktur- und Safety-Layouts für die Sphäre: **A) Längsgrade** (radiale Sektorschotten), **B) Breitengrade** (axiale Ring-Diaphragmen, „LAT“), **C) Kombination**. Bewertet werden **Statik/Dynamik**, **Druck/Brand/Hazard**, **OPS & Wartung**, **Routing/Komplexität**, **Masse & Fertigung**, **Erweiterbarkeit**. Ergebnis: Variante **C (Kombiniert)** liefert die beste Gesamtleistung; empfohlen als Baseline (EVOL-00 mit 12 Längsgrad-Schotten A–L + 3 LAT-Scheiben S40/EQ/N40, Ausbau zu 7 LAT in EVOL-01).
 
 **Project:** Sphere Space Station — Earth ONE (Ø 127,00 m)
 **Spin Law:** 1 g at r = 38,00 m → ω ≈ 0,508 s⁻¹ (≈ 4,85 rpm)
@@ -7,10 +36,6 @@
 ---
 
 ## Abstract / Kurzfassung
-
-**Ziel:** Vergleich dreier Struktur- und Safety-Layouts für die Sphäre: **A) Längsgrade** (radiale Sektorschotten), **B) Breitengrade** (axiale Ring-Diaphragmen, „LAT“), **C) Kombination**. Bewertet werden **Statik/Dynamik**, **Druck/Brand/Hazard**, **OPS & Wartung**, **Routing/Komplexität**, **Masse & Fertigung**, **Erweiterbarkeit**.
-
-**Ergebnis (TL;DR):** Variante **C (Kombiniert)** liefert die beste Gesamtleistung: höchste Torsions-/Biegesteifigkeit (multizellige Schale + Diaphragmen), beste Gefahreneindämmung in **radialer und axialer Richtung**, klare OPS-Sperrebenen und gute akustische Entkopplung. **Empfehlung:** C als **Baseline**; **gestufte Einführung**: EVOL-00 mit 12 Längsgrad-Schotten (A–L) + **3 LAT-Scheiben** (S40, EQ, N40), Ausbau zu **7 LAT** in EVOL-01.
 
 ---
 


### PR DESCRIPTION
#### Why
Align EVOL-00 deck specs with naming rules and provide English baseline content.

#### What
- add YAML front matter with ownership and review metadata
- standardize file names, EVOL references and language codes
- introduce bilingual summaries for key specs

#### Impact
Documentation update only; no functional changes expected.

#### Verification
- `pytest` *(fails: IndexError in animations test)*

#### Links

#### Checklist
- [x] Naming & front-matter consistent (EVOL/DISC/SYS/SYSID/LANG/STATE)
- [ ] Tables/figures numbered & referenced; SI units
- [ ] RFC/ADR/TST linked
- [ ] Minimum reviews requested (see Section B)


------
https://chatgpt.com/codex/tasks/task_e_68a0c8caf278832aabb11dda70f6c465