### PR TITLE
ci: rebase before pushing summary

### DIFF
--- a/.github/workflows/gitbook-style.yml
+++ b/.github/workflows/gitbook-style.yml
@@ -207,6 +207,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "chore: regenerate summary.md from book.json structure [skip ci]"
+            git pull --rebase origin main
             git push
           else
             echo "SUMMARY.MD OK"


### PR DESCRIPTION
## Summary
- ensure gitbook-style workflow rebases from origin before pushing summary updates

## Testing
- `yamllint .github/workflows/gitbook-style.yml` *(fails: line length warnings)*
- `pytest -q` *(fails: KeyboardInterrupt after tests; 22 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a2fe36ff4c832abc85d6f50cb056b3