### PR TITLE
fix: wrap wormhole footring units in math mode

### DIFF
--- a/documents/07-comprehensive-technical-documentation/7.4-research-development/7.4.3-spec-01-str-sys-core-traffic-sizing-0001-wormhole-diameter-trade-127m-254m-254x508m-254x1016m-en-de-v0.1.0-draft.md
+++ b/documents/07-comprehensive-technical-documentation/7.4-research-development/7.4.3-spec-01-str-sys-core-traffic-sizing-0001-wormhole-diameter-trade-127m-254m-254x508m-254x1016m-en-de-v0.1.0-draft.md
@@ -76,7 +76,7 @@ Wir modellieren den Wormhole-Durchmesser als **Packungs-/Hüllproblem**:
 * **Fahrzeug-Lane (inkl. Hülle & Clearance):** Kreis-Äquivalent $d_\text{lane} \approx 6\,\mathrm{m}$ (r = 3 m).
 * **Lane-Abstand:** $s=1{,}0\ldots 1{,}5\,\mathrm{m}$.
 * **Service-Trunks (PWR/COM/THM+SAFE):** ringförmig, äquiv. 2× **2 m** Bänder.
-* **Fußring (Evakuierung):** umlaufend **w\_foot = 2{,}0\ldots 3{,}0,\mathrm{m}**.
+* **Fußring (Evakuierung):** umlaufend **$w_\text{foot}=2{,}0\ldots 3{,}0\,\mathrm{m}$**.
 
 **Konservative Hüll-Schätzung:**
 


### PR DESCRIPTION
## Summary
- ensure wormhole footring width expression uses math mode so `\mathrm{m}` is valid

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a32458aad4832aa817a7bae84c3b8b