### PR TITLE
fix publisher workflow push from detached head

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -235,7 +235,7 @@ jobs:
             git add publish
             git commit -m "chore: selective publish → PDF (auto)"
             git pull --rebase origin "${GITHUB_REF_NAME}"
-            git push
+            git push origin HEAD:"${GITHUB_REF_NAME}"
           else
             echo "No changes in /publish — nothing to commit."
           fi


### PR DESCRIPTION
## Summary
- ensure selective publish workflow pushes new PDFs to the current branch by specifying the branch name

## Testing
- `yamllint .github/workflows/publisher.yml` *(fails: line-length warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a3300be438832a995bda25e377c426