### PR TITLE
Cascade workflows and scope publisher to book root

### DIFF
--- a/.github/workflows/ensure-readme.yml
+++ b/.github/workflows/ensure-readme.yml
@@ -2,7 +2,6 @@ name: Ensure readme.md in every folder
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -33,6 +33,26 @@ jobs:
           echo "Comparing $BEFORE -> $SHA"
           CHANGED_FILES=$(git diff --name-only "$BEFORE" "$SHA")
 
+          BOOK_ROOT=$(python3 - <<'PY'
+import json, sys
+try:
+    with open('book.json','r',encoding='utf-8') as f:
+        root=json.load(f).get('root','.')
+        if root.startswith('./'):
+            root=root[2:]
+        print(root)
+except Exception:
+    print('.')
+PY
+          )
+          if [[ "$BOOK_ROOT" != "." ]]; then
+            if ! grep -q "^$BOOK_ROOT/" <<<"$CHANGED_FILES"; then
+              echo "ℹ No changes detected in $BOOK_ROOT — exiting early."
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
           # Find manifest
           if [[ -f publish.yaml ]]; then
             MANIFEST="publish.yaml"


### PR DESCRIPTION
## Summary
- run readme enforcement workflow only on push or manual trigger
- skip PDF publishing unless a push touches the GitBook root from `book.json`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a802e1bcd0832aa2ff7ec1c04d004b