### PR TITLE
fix: handle space after colon when detecting book root

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -38,7 +38,7 @@ jobs:
           CHANGED_FILES=$(git diff --name-only "$BEFORE" "$SHA")
 
           # determine GitBook root from book.json (if available) without Python
-          BOOK_ROOT="$(grep -o '"root"[[:space:]]*:[[:space:]]*"[^"]*"' book.json 2>/dev/null | head -n1 | sed -E 's/.*:"([^"]*)"/\1/' | sed 's#^\./##')"
+          BOOK_ROOT="$(grep -o '"root"[[:space:]]*:[[:space:]]*"[^"]*"' book.json 2>/dev/null | head -n1 | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/' | sed 's#^\./##')"
           if [[ -n "$BOOK_ROOT" && "$BOOK_ROOT" != "." ]]; then
             if ! grep -q "^$BOOK_ROOT/" <<<"$CHANGED_FILES"; then
               echo "ℹ No changes detected in $BOOK_ROOT — exiting early."


### PR DESCRIPTION
## Summary
- ensure book root extraction tolerates whitespace after the colon

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8eda57d60832aa6acf758e3baed11