### PR TITLE
build: add publish flag workflow and integrate

### DIFF
--- a/.github/tools/README.md
+++ b/.github/tools/README.md
@@ -1,0 +1,5 @@
+# GitHub Tools
+
+Utility scripts used by the repository's workflows.
+
+This directory groups helper scripts, such as publishing utilities.

--- a/.github/tools/publishing/README.md
+++ b/.github/tools/publishing/README.md
@@ -1,0 +1,5 @@
+# Publishing Tools
+
+Scripts assisting selective publishing workflows.
+
+`set_publish_flag.py` updates build flags in `publish.yml` based on repository changes.

--- a/.github/workflows/check-if-to-publish.yml
+++ b/.github/workflows/check-if-to-publish.yml
@@ -1,0 +1,34 @@
+name: Check if to publish
+
+on:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  set-build-flag:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set publish build flags
+        run: |
+          pip install pyyaml
+          commit="${GITHUB_SHA}"
+          base="${{ github.event.before }}"
+          python .github/tools/publishing/set_publish_flag.py --commit "$commit" --base "$base" --reset-others
+      - name: Commit publish flag updates
+        run: |
+          if [ -n "$(git status --porcelain publish.yml publish.yaml 2>/dev/null)" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add publish.yml publish.yaml 2>/dev/null
+            git commit -m "chore: update publish build flags"
+            git push
+          else
+            echo "No build flag changes."
+          fi

--- a/.github/workflows/engineering-document-formatter.yml
+++ b/.github/workflows/engineering-document-formatter.yml
@@ -106,14 +106,37 @@ jobs:
           PYTHON
 
       - name: Commit changes
+        id: commit
         run: |
-          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "chore: ensure engineering document YAML headers"
-            git pull --rebase origin "$branch"
-            git push origin HEAD:"$branch"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "All engineering documents contain YAML headers."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Update publish build flags
+        if: steps.commit.outputs.committed == 'true'
+        id: flags
+        run: |
+          pip install pyyaml
+          commit=$(git rev-parse HEAD)
+          base=$(git rev-parse HEAD^)
+          python .github/tools/publishing/set_publish_flag.py --commit "$commit" --base "$base" --reset-others
+          if [ -n "$(git status --porcelain publish.yml publish.yaml 2>/dev/null)" ]; then
+            git add publish.yml publish.yaml 2>/dev/null
+            git commit -m "chore: update publish build flags"
+            echo "flags=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true' || steps.flags.outputs.flags == 'true'
+        run: |
+          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
+          git pull --rebase origin "$branch"
+          git push origin HEAD:"$branch"

--- a/.github/workflows/ensure-readme.yml
+++ b/.github/workflows/ensure-readme.yml
@@ -1,7 +1,10 @@
 name: Ensure readme.md in every folder
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Check if to publish"]
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -9,10 +12,14 @@ permissions:
 
 jobs:
   ensure-readmes:
+    if: github.actor != 'github-actions[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
       - name: Create missing readme.md files
         shell: bash
@@ -33,13 +40,38 @@ jobs:
             created=$((created+1))
           done < <(find . -type d -not -path '*/.*' -print0)
 
-          # Nur committen/pushen, wenn es Änderungen gab
-          if [[ $created -gt 0 ]]; then
+      - name: Commit changes
+        id: commit
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add -A
-            git commit -m "chore: add missing readme.md files"
-            git push
+            git commit -am "chore: add missing readme.md files"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No missing readme.md files found."
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Update publish build flags
+        if: steps.commit.outputs.committed == 'true'
+        id: flags
+        run: |
+          pip install pyyaml
+          commit=$(git rev-parse HEAD)
+          base=$(git rev-parse HEAD^)
+          python .github/tools/publishing/set_publish_flag.py --commit "$commit" --base "$base" --reset-others
+          if [ -n "$(git status --porcelain publish.yml publish.yaml 2>/dev/null)" ]; then
+            git add publish.yml publish.yaml 2>/dev/null
+            git commit -m "chore: update publish build flags"
+            echo "flags=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true' || steps.flags.outputs.flags == 'true'
+        run: |
+          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
+          git pull --rebase origin "$branch"
+          git push origin HEAD:"$branch"

--- a/.github/workflows/gitbook-style.yml
+++ b/.github/workflows/gitbook-style.yml
@@ -30,9 +30,7 @@ jobs:
               if src == dst:
                   return
               dst.parent.mkdir(parents=True, exist_ok=True)
-              # Handle case-insensitive FS or collisions
               if dst.exists() and src.resolve() != dst.resolve():
-                  # If content identical, just remove src after mv attempt
                   try:
                       subprocess.run(['git', 'rm', '-r', '--cached', str(dst)], check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                   except Exception:
@@ -40,12 +38,10 @@ jobs:
               subprocess.run(['git', 'mv', str(src), str(dst)], check=False)
 
           for root, dirs, files in os.walk(ROOT, topdown=True):
-              # prune directories
               rel = Path(root).relative_to(ROOT)
               if any(p in SKIP_DIRS for p in rel.parts):
                   dirs[:] = []
                   continue
-              # filter & normalize directory names first
               for d in list(dirs):
                   if d in SKIP_DIRS or d.startswith('.git'):
                       dirs.remove(d)
@@ -53,10 +49,7 @@ jobs:
                   new = re.sub(r'[^a-z0-9.-]+', '-', d.lower()).strip('-')
                   if new != d:
                       safe_git_mv(Path(root)/d, Path(root)/new)
-                      # reflect rename in traversal
                       dirs[dirs.index(d)] = new
-
-              # files
               for name in files:
                   if name.startswith('.') or name.endswith('.py'):
                       continue
@@ -73,7 +66,6 @@ jobs:
           import subprocess
           import sys
 
-          # --- helpers ---
           def read_json(path: Path):
               try:
                   return json.loads(path.read_text(encoding='utf-8'))
@@ -89,31 +81,25 @@ jobs:
 
           def title_from_filename(p: Path):
               name = p.stem
-              # Prefer natural words from kebab/underscore
               name = re.sub(r'[-_]+', ' ', name)
               name = re.sub(r'\s+', ' ', name).strip()
               return name.title() if name else p.stem
 
           def natural_key(s: str):
-              # for natural sorting: "file2" before "file10"
               return [int(t) if t.isdigit() else t.lower() for t in re.split(r'(\d+)', s)]
 
-          # --- load book.json & paths ---
           book = read_json(Path('book.json')) if Path('book.json').exists() else {}
           root_dir = Path(book.get('root', '.')).resolve()
           structure = book.get('structure', {})
           summary_rel = structure.get('summary', 'summary.md')
           summary_path = (root_dir / summary_rel).resolve()
 
-          # normalized skip sets
           SKIP_DIRS = {'.git', '.github', 'node_modules', '__pycache__', '.venv', 'simulations'}
           MD_EXT = {'.md'}
 
-          # --- collect tree ---
           def md_files_in_dir(dir_path: Path):
               files = [p for p in dir_path.iterdir() if p.is_file() and p.suffix.lower() in MD_EXT]
-              files = [p for p in files if p.resolve() != summary_path.resolve()]  # skip summary itself
-              # Prefer README.md first if present
+              files = [p for p in files if p.resolve() != summary_path.resolve()]
               readme = [p for p in files if p.name.lower() == 'readme.md']
               others = sorted([p for p in files if p.name.lower() != 'readme.md'], key=lambda p: natural_key(p.name))
               return (readme + others)
@@ -124,7 +110,6 @@ jobs:
               return sorted(dirs, key=lambda p: natural_key(p.name))
 
           def rel_link(p: Path):
-              # POSIX style for markdown links
               return str(p.relative_to(root_dir)).replace('\\','/')
 
           def make_item_title(p: Path):
@@ -133,14 +118,12 @@ jobs:
               except Exception:
                   text = ''
               h = first_heading(text) or title_from_filename(p)
-              # sanitize brackets in titles
               h = h.replace('[','(').replace(']',')')
               return h
 
           lines = ['# Summary', '']
-          
+
           def emit_dir(dir_path: Path, level: int):
-              # directory header: link README if present; else plain title (not a link)
               files = md_files_in_dir(dir_path)
               readme = next((p for p in files if p.name.lower() == 'readme.md'), None)
               if dir_path != root_dir:
@@ -154,40 +137,29 @@ jobs:
                   else:
                       lines.append('  ' * level + f"* {title}")
 
-              # files (excluding README already handled)
               for p in files:
                   if p.name.lower() == 'readme.md' and dir_path != root_dir:
                       continue
                   if dir_path == root_dir and p.name.lower() == 'readme.md':
-                      # top-level README first
                       lines.append('  ' * level + f"* [{make_item_title(p)}]({rel_link(p)})")
                   elif p.name.lower() != 'readme.md':
                       lines.append('  ' * (level + (0 if dir_path==root_dir else 1)) + f"* [{make_item_title(p)}]({rel_link(p)})")
 
-              # recurse into subdirs
               for d in child_dirs(dir_path):
                   emit_dir(d, level if dir_path==root_dir else level+1)
 
-          # Start: top-level README first, then others, then dirs
           top_files = md_files_in_dir(root_dir)
           top_readme = [p for p in top_files if p.name.lower() == 'readme.md']
           top_others = [p for p in top_files if p.name.lower() != 'readme.md']
 
-          # Emit top-level README (if any)
           for p in top_readme:
               lines.append(f"* [{make_item_title(p)}]({rel_link(p)})")
-
-          # Emit other top-level files
           for p in top_others:
               lines.append(f"* [{make_item_title(p)}]({rel_link(p)})")
-
-          # Emit directories
           for d in child_dirs(root_dir):
               emit_dir(d, level=0)
 
           new_content = "\n".join(lines).rstrip() + "\n"
-
-          # Ensure parent exists
           summary_path.parent.mkdir(parents=True, exist_ok=True)
           old_content = ''
           if summary_path.exists():
@@ -206,14 +178,37 @@ jobs:
           PYTHON
 
       - name: Commit changes
+        id: commit
         run: |
-          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "chore: regenerate summary.md from book.json structure [skip ci]"
-            git pull --rebase origin "$branch"
-            git push origin HEAD:"$branch"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "SUMMARY.MD OK"
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Update publish build flags
+        if: steps.commit.outputs.committed == 'true'
+        id: flags
+        run: |
+          pip install pyyaml
+          commit=$(git rev-parse HEAD)
+          base=$(git rev-parse HEAD^)
+          python .github/tools/publishing/set_publish_flag.py --commit "$commit" --base "$base" --reset-others
+          if [ -n "$(git status --porcelain publish.yml publish.yaml 2>/dev/null)" ]; then
+            git add publish.yml publish.yaml 2>/dev/null
+            git commit -m "chore: update publish build flags"
+            echo "flags=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "flags=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Push changes
+        if: steps.commit.outputs.committed == 'true' || steps.flags.outputs.flags == 'true'
+        run: |
+          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
+          git pull --rebase origin "$branch"
+          git push origin HEAD:"$branch"

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -21,69 +21,29 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
 
-      - name: Get changed files and check manifest relevance
-        id: precheck
-        shell: bash
+      - name: Determine publish targets
+        id: prep
         run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            BEFORE="${{ github.event.workflow_run.head_sha }}"
-          else
-            BEFORE="$(git rev-parse HEAD^ || echo '')"
-          fi
-          SHA="$(git rev-parse HEAD)"
-          echo "before=$BEFORE" >> "$GITHUB_OUTPUT"
-          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "Comparing $BEFORE -> $SHA"
-          CHANGED_FILES=$(git diff --name-only "$BEFORE" "$SHA")
-
-          # determine GitBook root from book.json (if available) without Python
-          BOOK_ROOT="$(grep -o '"root"[[:space:]]*:[[:space:]]*"[^"]*"' book.json 2>/dev/null | head -n1 | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/' | sed 's#^\./##')"
-          if [[ -n "$BOOK_ROOT" && "$BOOK_ROOT" != "." ]]; then
-            if ! grep -q "^$BOOK_ROOT/" <<<"$CHANGED_FILES"; then
-              echo "ℹ No changes detected in $BOOK_ROOT — exiting early."
-              echo "should_publish=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          fi
-
-          # Find manifest
-          if [[ -f publish.yaml ]]; then
-            MANIFEST="publish.yaml"
-          elif [[ -f publish.yml ]]; then
-            MANIFEST="publish.yml"
-          else
-            echo "❌ No publish.yaml or publish.yml found in repo."
-            exit 1
-          fi
-          echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
-          echo "✓ Manifest found: $MANIFEST"
-          echo "Changed files:\n$CHANGED_FILES"
-
-          NEED_PUBLISH=false
-          # extract all `path` entries from the manifest regardless of indentation
-          MAP_PATHS=$(awk -F': *' '/^[[:space:]]*-[[:space:]]*path:/ {print $2}' "$MANIFEST")
-          for PATH in $MAP_PATHS; do
-            if grep -qE "^${PATH}(/|$)" <<<"$CHANGED_FILES"; then
-              NEED_PUBLISH=true
-              break
-            fi
-          done
-          if [[ "$NEED_PUBLISH" != "true" ]]; then
-            echo "ℹ No relevant changes detected — exiting early."
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          python - <<'PY'
+          import yaml, json, os
+          manifest = 'publish.yml' if os.path.exists('publish.yml') else 'publish.yaml'
+          with open(manifest, 'r', encoding='utf-8') as f:
+              data = yaml.safe_load(f) or {}
+          targets = [e for e in data.get('publish', []) if e.get('build')]
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as out:
+              out.write(f"manifest={manifest}\n")
+              out.write(f"targets={json.dumps(targets)}\n")
+              out.write(f"should_publish={'true' if targets else 'false'}\n")
+          PY
 
       - name: Set up Python and install dependencies
-        if: steps.precheck.outputs.should_publish == 'true'
+        if: steps.prep.outputs.should_publish == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
       - name: Install dependencies (PyYAML, Pandoc/LaTeX, emoji fonts)
-        if: steps.precheck.outputs.should_publish == 'true'
+        if: steps.prep.outputs.should_publish == 'true'
         run: |
           pip install pyyaml
           sudo apt-get update
@@ -95,24 +55,18 @@ jobs:
           wget https://gist.githubusercontent.com/zr-tex8r/a5410ad20ab291c390884b960c900537/raw/latex-emoji.lua -O latex-emoji.lua
 
       - name: Selective publish & PDF conversion
-        if: steps.precheck.outputs.should_publish == 'true'
+        if: steps.prep.outputs.should_publish == 'true'
         env:
-          MANIFEST: ${{ steps.precheck.outputs.manifest }}
-          BEFORE: ${{ steps.precheck.outputs.before }}
-          GITHUB_SHA: ${{ steps.precheck.outputs.sha }}
-        shell: bash
+          MANIFEST: ${{ steps.prep.outputs.manifest }}
+          TARGETS: ${{ steps.prep.outputs.targets }}
         run: |
           set -euo pipefail
           mkdir -p publish
           python3 <<'PY'
           import os, subprocess, sys, tempfile, yaml, pathlib, json
-
-          subs = {"₀":"$_0$","₁":"$_1$","₂":"$_2$","₃":"$_3$","₄":"$_4$",
-                  "₅":"$_5$","₆":"$_6$","₇":"$_7$","₈":"$_8$","₉":"$_9$"}
-
+          subs = {"₀":"$_0$","₁":"$_1$","₂":"$_2$","₃":"$_3$","₄":"$_4$","₅":"$_5$","₆":"$_6$","₇":"$_7$","₈":"$_8$","₉":"$_9$"}
           def normalize_md(text):
               return "".join(subs.get(ch, ch) for ch in text)
-
           def get_book_title(folder):
               try:
                   with open("book.json", "r", encoding="utf-8") as f:
@@ -125,7 +79,6 @@ jobs:
               except Exception:
                   pass
               return None
-
           def run_pandoc(md_path, pdf_out, add_toc=False, title=None):
               pathlib.Path(os.path.dirname(pdf_out)).mkdir(parents=True, exist_ok=True)
               cmd = [
@@ -144,7 +97,6 @@ jobs:
                   cmd.extend(["-V", f"title={title}"])
               print("→ Pandoc:", " ".join(cmd))
               subprocess.check_call(cmd)
-
           def convert_file(md_file, pdf_out):
               with open(md_file, "r", encoding="utf-8") as f:
                   content = normalize_md(f.read())
@@ -155,7 +107,6 @@ jobs:
                   run_pandoc(tmp_md, pdf_out)
               finally:
                   os.unlink(tmp_md)
-
           def extract_md_paths_from_summary(folder):
               summary_path = os.path.join(folder, "summary.md")
               if not os.path.exists(summary_path):
@@ -168,7 +119,6 @@ jobs:
                           if not match.startswith("http://") and not match.startswith("https://"):
                               paths.append(os.path.normpath(os.path.join(folder, match)))
               return paths
-
           def convert_folder(folder, pdf_out):
               md_files = extract_md_paths_from_summary(folder)
               if not md_files:
@@ -198,41 +148,40 @@ jobs:
                   run_pandoc(tmp_md, pdf_out, add_toc=True, title=title)
               finally:
                   os.unlink(tmp_md)
-
-          BEFORE = os.environ["BEFORE"]
-          SHA = os.environ["GITHUB_SHA"]
-          changed_files = os.popen(f"git diff --name-only {BEFORE} {SHA}").read().splitlines()
-          with open(os.environ["MANIFEST"], "r", encoding="utf-8") as f:
-              entries = yaml.safe_load(f).get("publish", [])
-
-          for entry in entries:
+          manifest = os.environ["MANIFEST"]
+          data = yaml.safe_load(open(manifest, "r", encoding="utf-8")) or {}
+          targets = json.loads(os.environ["TARGETS"])
+          for entry in targets:
               path = entry.get("path")
-              out  = entry.get("out")
-              typ  = entry.get("type")
-              if any(cf == path or cf.startswith(f"{path}/") for cf in changed_files):
-                  pdf_out = os.path.join("publish", out)
-                  print(f"✔ Changes in {path} → creating {pdf_out}")
-                  if typ == "file":
-                      convert_file(path, pdf_out)
-                  elif typ == "folder":
-                      convert_folder(path, pdf_out)
-                  else:
-                      print(f"⚠ Unknown type '{typ}' — skipping.")
+              out = entry.get("out")
+              typ = entry.get("type")
+              pdf_out = os.path.join("publish", out)
+              print(f"✔ Building {pdf_out} from {path}")
+              if typ == "file":
+                  convert_file(path, pdf_out)
+              elif typ == "folder":
+                  convert_folder(path, pdf_out)
               else:
-                  print(f"ℹ No changes in {path} → skipping.")
+                  print(f"⚠ Unknown type '{typ}' — skipping.")
+              for e in data.get("publish", []):
+                  if e.get("path") == path:
+                      e["build"] = False
+          with open(manifest, "w", encoding="utf-8") as f:
+              yaml.safe_dump(data, f, sort_keys=False, allow_unicode=True)
           PY
 
       - name: Commit and push generated PDFs
-        if: steps.precheck.outputs.should_publish == 'true'
-        shell: bash
+        if: steps.prep.outputs.should_publish == 'true'
+        env:
+          MANIFEST: ${{ steps.prep.outputs.manifest }}
         run: |
-          if [[ -n "$(git status --porcelain publish)" ]]; then
+          if [ -n "$(git status --porcelain publish $MANIFEST)" ]; then
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add publish
+            git add publish "$MANIFEST"
             git commit -m "chore: selective publish → PDF (auto)"
             git pull --rebase origin "${GITHUB_REF_NAME}"
             git push origin HEAD:"${GITHUB_REF_NAME}"
           else
-            echo "No changes in /publish — nothing to commit."
+            echo "No changes in publish or manifest — nothing to commit."
           fi


### PR DESCRIPTION
## Summary
- add check-if-to-publish workflow to toggle `publish.yml` build flags
- chain existing workflows and update them to call `set_publish_flag.py`
- rework publisher to build PDFs based on `build` flags and reset them afterwards
- document tooling directories with READMEs

## Testing
- `pip install -r requirements.txt`
- `pytest` *(partially: interrupted after running 22 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a993a6df24832aaf7525932a876b50