### PR TITLE
fix: correct git remote url in publish workflow

### DIFF
--- a/.github/workflows/check-if-to-publish.yml
+++ b/.github/workflows/check-if-to-publish.yml
@@ -26,9 +26,10 @@ jobs:
             --base "$base"
       - name: Set up git for pushing
         run: |
-          git remote set-url origin \
-            https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/\
-            ${{ github.repository }}.git
+          token="${{ secrets.GITHUB_TOKEN }}"
+          repo="${{ github.repository }}"
+          repo_url="https://x-access-token:${token}@github.com/${repo}.git"
+          git remote set-url origin "$repo_url"
       - name: Commit publish flag updates
         run: |
           status="$(git status --porcelain \


### PR DESCRIPTION
## Summary
- fix `git remote set-url` in check-if-to-publish workflow by constructing full repository URL before invocation

## Testing
- `yamllint .github/workflows/check-if-to-publish.yml`
- `pytest` *(fails: IndexError: list index out of range in simulations/unit_tests/test_function_calls.py::test_animations)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b7449d08832a855f92780af9cd90