### PR TITLE
fix: enable selective publish outputs

### DIFF
--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -25,11 +25,12 @@ jobs:
         with: { python-version: '3.12' }
 
       - name: Selective publish via tool
+        id: prep
         run: |
             python .github/tools/publishing/publisher.py --use-summary
 
       - name: Commit and push generated PDFs
-        if: steps.prep.outputs.should_publish == 'true'
+        if: steps.prep.outputs.built_count != '0'
         env:
           MANIFEST: ${{ steps.prep.outputs.manifest }}
         run: |


### PR DESCRIPTION
## Summary
- ensure publisher workflow captures outputs from publisher.py
- commit PDFs only when files were built

## Testing
- `pytest` *(fails: IndexError: list index out of range)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bb8aa9b8832a84f2962ddd472373