### PR TITLE
refactor: orchestrate publishing with reusable workflows

### DIFF
--- a/.github/workflows/check-if-to-publish.yml
+++ b/.github/workflows/check-if-to-publish.yml
@@ -1,9 +1,9 @@
 ---
 name: Check if to publish
 
-"on":
-  push: {}
-  workflow_dispatch: {}
+on:
+  workflow_call:
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/engineering-document-formatter.yml
+++ b/.github/workflows/engineering-document-formatter.yml
@@ -1,21 +1,18 @@
 name: Engineering Document Formatter
 
 on:
-  workflow_run:
-    workflows: ["Ensure readme.md in every folder"]
-    types:
-      - completed
+  workflow_call:
   workflow_dispatch:
 
 jobs:
   format:
-    if: github.actor != 'github-actions[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Ensure engineering document YAML headers
         run: |
@@ -137,6 +134,6 @@ jobs:
       - name: Push changes
         if: steps.commit.outputs.committed == 'true' || steps.flags.outputs.flags == 'true'
         run: |
-          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
+          branch="${{ github.ref_name }}"
           git pull --rebase origin "$branch"
           git push origin HEAD:"$branch"

--- a/.github/workflows/ensure-readme.yml
+++ b/.github/workflows/ensure-readme.yml
@@ -1,10 +1,7 @@
 name: Ensure readme.md in every folder
 
 on:
-  workflow_run:
-    workflows: ["Check if to publish"]
-    types:
-      - completed
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -12,14 +9,14 @@ permissions:
 
 jobs:
   ensure-readmes:
-    if: github.actor != 'github-actions[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Create missing readme.md files
         shell: bash
@@ -72,6 +69,6 @@ jobs:
       - name: Push changes
         if: steps.commit.outputs.committed == 'true' || steps.flags.outputs.flags == 'true'
         run: |
-          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
+          branch="${{ github.ref_name }}"
           git pull --rebase origin "$branch"
           git push origin HEAD:"$branch"

--- a/.github/workflows/gitbook-style.yml
+++ b/.github/workflows/gitbook-style.yml
@@ -1,21 +1,18 @@
 name: GitBook Style Rename
 
 on:
-  workflow_run:
-    workflows: ["Engineering Document Formatter"]
-    types:
-      - completed
+  workflow_call:
   workflow_dispatch:
 
 jobs:
   rename-and-summary:
-    if: github.actor != 'github-actions[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.ref }}
 
       - name: Rename files to GitBook style
         run: |
@@ -209,6 +206,6 @@ jobs:
       - name: Push changes
         if: steps.commit.outputs.committed == 'true' || steps.flags.outputs.flags == 'true'
         run: |
-          branch="${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref_name }}"
+          branch="${{ github.ref_name }}"
           git pull --rebase origin "$branch"
           git push origin HEAD:"$branch"

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -1,0 +1,31 @@
+name: Orchestrator
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  check_if_to_publish:
+    uses: ./.github/workflows/check-if-to-publish.yml
+    secrets: inherit
+
+  ensure_readme:
+    needs: check_if_to_publish
+    uses: ./.github/workflows/ensure-readme.yml
+    secrets: inherit
+
+  format_engineering_docs:
+    needs: ensure_readme
+    uses: ./.github/workflows/engineering-document-formatter.yml
+    secrets: inherit
+
+  gitbook_style_rename:
+    needs: format_engineering_docs
+    uses: ./.github/workflows/gitbook-style.yml
+    secrets: inherit
+
+  selective_publish_pdf:
+    needs: gitbook_style_rename
+    uses: ./.github/workflows/publisher.yml
+    secrets: inherit
+

--- a/.github/workflows/publisher.yml
+++ b/.github/workflows/publisher.yml
@@ -1,15 +1,22 @@
 name: Selective Publish to PDF
 
 on:
-  workflow_run:
-    workflows: ["GitBook Style Rename"]
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      use_summary:
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
+    inputs:
+      use_summary:
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   selective-publish:
-    if: github.actor != 'github-actions[bot]' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -19,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || github.ref }}
+          ref: ${{ github.ref }}
 
       - uses: actions/setup-python@v5
         with: { python-version: '3.12' }
@@ -27,7 +34,7 @@ jobs:
       - name: Selective publish via tool
         id: prep
         run: |
-            python .github/tools/publishing/publisher.py --use-summary
+            python .github/tools/publishing/publisher.py ${{ inputs.use_summary && '--use-summary' || '' }}
 
       - name: Commit and push generated PDFs
         if: steps.prep.outputs.built_count != '0'


### PR DESCRIPTION
## Summary
- convert publishing workflow chain to reusable workflows
- introduce orchestrator workflow to call publishing steps sequentially
- allow publisher workflow to accept optional `use_summary` flag

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9cf2eef24832a9320d1a5a3b6704f