### PR TITLE
fix: stage new readme files in ensure-readme workflow

### DIFF
--- a/.github/workflows/ensure-readme.yml
+++ b/.github/workflows/ensure-readme.yml
@@ -43,7 +43,8 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -am "chore: add missing readme.md files"
+            git add .
+            git commit -m "chore: add missing readme.md files"
             echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "No missing readme.md files found."

--- a/documents/07-comprehensive-technical-documentation/7.1 project overviews and fibels/readme.md
+++ b/documents/07-comprehensive-technical-documentation/7.1 project overviews and fibels/readme.md
@@ -1,0 +1,3 @@
+## 7.1 Project Overviews and Fibels
+
+Project overviews and fibel documents for Sphere Space Station Earth ONE.


### PR DESCRIPTION
## Summary
- ensure-readme workflow now stages new files before committing
- add README for 7.1 project overviews and fibels documentation folder

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(hangs after summary; interrupted with Ctrl+C showing `22 passed`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa15121ea8832a94842b23195aaae0